### PR TITLE
chore/fix: enhancing Core V2 Integration

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -34,6 +34,20 @@ jobs:
         python -m pip install uv
         python -m uv sync
 
+    - name: Cache HuggingFace embedding model
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/huggingface/hub/models--sentence-transformers--all-MiniLM-L6-v2
+        key: hf-model-all-MiniLM-L6-v2
+
+    - name: Download embedding model
+      run: |
+        uv run python -c "
+        from core.v1.engine.indexes.embeddings.model_manager import ensure_model
+        ensure_model('all-MiniLM-L6-v2')
+        print('Model ready')
+        "
+
     - name: Run System Tests
       run: |
         uv run pytest tests/system/ -q --tb=short

--- a/apps/indexed/src/indexed/app.py
+++ b/apps/indexed/src/indexed/app.py
@@ -66,6 +66,26 @@ app = typer.Typer(
 )
 
 
+_configs_registered = False
+
+
+def _ensure_configs_registered() -> None:
+    """Register GeneralConfig and v2 core configs once per process."""
+    global _configs_registered
+    if _configs_registered:
+        return
+    from indexed_config import ConfigService
+
+    from core.v2.config import register_config as _register_v2_config
+
+    from .services.engine_router import GeneralConfig as _GeneralConfig
+
+    cfg_svc = ConfigService.instance()
+    cfg_svc.register(_GeneralConfig, path="general")
+    _register_v2_config(cfg_svc)
+    _configs_registered = True
+
+
 @app.callback(invoke_without_command=True)
 def _init_app(
     ctx: typer.Context,
@@ -149,7 +169,18 @@ def _init_app(
     # Store resolved mode_override and engine on ctx.obj for subcommands to access
     ctx.ensure_object(dict)
     ctx.obj["mode_override"] = "local" if local else None
-    ctx.obj["engine"] = engine.lower() if engine else None
+    if engine is not None:
+        from .services.engine_router import VALID_ENGINES, normalize_engine
+
+        normalized = normalize_engine(engine)
+        if normalized is None:
+            raise typer.BadParameter(
+                f"Engine must be one of {sorted(VALID_ENGINES)}; got {engine!r}",
+                param_hint="--engine",
+            )
+        ctx.obj["engine"] = normalized
+    else:
+        ctx.obj["engine"] = None
 
     if local:
         from indexed_config import ensure_storage_dirs, get_local_root
@@ -158,16 +189,10 @@ def _init_app(
         local_root = get_local_root(workspace)
         ensure_storage_dirs(local_root, is_local=True)
 
-    # Register GeneralConfig and v2 core configs so [general] engine and
-    # [core.v2.*] settings are available in config.toml (explicit registration,
-    # never at import time — see cleanup.md §8)
-    from indexed_config import ConfigService
-    from core.v2.config import register_config as _register_v2_config
-    from .services.engine_router import GeneralConfig as _GeneralConfig
-
-    _cfg_svc = ConfigService.instance()
-    _cfg_svc.register(_GeneralConfig, path="general")
-    _register_v2_config(_cfg_svc)
+    # Defer config registration until a real subcommand is being invoked.
+    # Skipping on bare `--help` keeps cold-start sub-second.
+    if ctx.invoked_subcommand is not None and not ctx.resilient_parsing:
+        _ensure_configs_registered()
 
 
 from . import config, info, knowledge, mcp  # noqa: E402

--- a/apps/indexed/src/indexed/knowledge/commands/_create_helpers.py
+++ b/apps/indexed/src/indexed/knowledge/commands/_create_helpers.py
@@ -34,7 +34,6 @@ def _build_v2_connector(cfg: "SourceConfig", config_service: Any) -> Any:
         return FileSystemConnector(
             path=cfg.base_url_or_path,
             include_patterns=cfg.reader_opts.get("includePatterns", ["*"]),
-            exclude_patterns=cfg.reader_opts.get("excludePatterns", []),
             fail_fast=cfg.reader_opts.get("failFast", False),
         )
 

--- a/apps/indexed/src/indexed/knowledge/commands/inspect.py
+++ b/apps/indexed/src/indexed/knowledge/commands/inspect.py
@@ -354,9 +354,7 @@ def _list_collections_per_row(
 
     if v1_names:
         try:
-            collections.extend(
-                inspect_svc(v1_names, collections_path=preferred_path)
-            )
+            collections.extend(inspect_svc(v1_names, collections_path=preferred_path))
         except Exception:
             pass
 

--- a/apps/indexed/src/indexed/knowledge/commands/inspect.py
+++ b/apps/indexed/src/indexed/knowledge/commands/inspect.py
@@ -6,7 +6,8 @@ with Rich or JSON. Presentation and command logic are now unified in this file.
 """
 
 import typer
-from typing import List, Optional, TYPE_CHECKING
+from pathlib import Path
+from typing import Callable, List, Optional, TYPE_CHECKING
 from rich.columns import Columns
 
 from ...utils.console import console
@@ -205,10 +206,12 @@ def inspect_collections(
     # Use module-level lazy-loaded services (supports mocking in tests)
     from . import inspect as this_module
     from ...utils.storage_info import resolve_preferred_collections_path
-    from ...services.engine_router import get_effective_engine
+    from ...services.engine_router import (
+        detect_collection_engine,
+        get_effective_engine,
+    )
     from pathlib import Path
 
-    active_engine = get_effective_engine(engine)
     inspect_svc = this_module.inspect
 
     # Prefer local collections over global
@@ -217,6 +220,9 @@ def inspect_collections(
 
     # Fetch collection info from core - this is connection-agnostic
     if name:
+        active_engine = get_effective_engine(
+            engine, collection=name, collections_path=preferred_path
+        )
         if active_engine == "v2":
             from core.v2.services import inspect as v2_inspect, status as v2_status
 
@@ -265,13 +271,20 @@ def inspect_collections(
             else:
                 format_collection_detail(collections[0])
     else:
-        if active_engine == "v2":
-            from core.v2.services import status as v2_status
+        # List view: when --engine flag is set, force every row through that
+        # engine (escape hatch). Otherwise detect per-collection from manifest.
+        if engine is not None:
+            active_engine = get_effective_engine(engine)
+            if active_engine == "v2":
+                from core.v2.services import status as v2_status
 
-            collections = v2_status(collections_dir=preferred_dir)
+                collections = v2_status(collections_dir=preferred_dir)
+            else:
+                collections = inspect_svc(collections_path=preferred_path)
         else:
-            # List all collections (no progress bar)
-            collections = inspect_svc(collections_path=preferred_path)
+            collections = _list_collections_per_row(
+                preferred_path, preferred_dir, inspect_svc, detect_collection_engine
+            )
 
         if not collections:
             console.print(
@@ -287,6 +300,79 @@ def inspect_collections(
             format_collections_json(collections)
         else:
             format_collection_list(collections, verbose=verbose)
+
+
+def _list_collections_per_row(
+    preferred_path: str,
+    preferred_dir: Path,
+    inspect_svc: Callable,
+    detect_engine: Callable,
+) -> List["CollectionInfo"]:
+    """Inspect every collection under ``preferred_path`` using its own engine.
+
+    Falls back to the configured default engine when a manifest is absent or
+    unreadable. Skips entries that fail to inspect rather than aborting the
+    whole listing — half-written collections still appear nowhere instead of
+    crashing the list view.
+    """
+    from ...services.engine_router import get_effective_engine
+
+    # When the storage directory is missing or contains no manifested
+    # collections, fall back to the v1 list service. v1 ``inspect()`` walks the
+    # configured collections directory itself, so it stays the source of truth
+    # for "no collections found" behavior (and keeps existing tests that mock
+    # ``inspect_svc`` working without setting up a real directory tree).
+    if not preferred_dir.exists():
+        try:
+            return list(inspect_svc(collections_path=preferred_path))
+        except Exception:
+            return []
+
+    names = sorted(
+        d.name
+        for d in preferred_dir.iterdir()
+        if d.is_dir() and (d / "manifest.json").exists()
+    )
+    if not names:
+        try:
+            return list(inspect_svc(collections_path=preferred_path))
+        except Exception:
+            return []
+
+    config_default = get_effective_engine(None)
+
+    v1_names: list[str] = []
+    v2_names: list[str] = []
+    for n in names:
+        detected = detect_engine(n, preferred_path) or config_default
+        if detected == "v2":
+            v2_names.append(n)
+        else:
+            v1_names.append(n)
+
+    collections: list = []
+
+    if v1_names:
+        try:
+            collections.extend(
+                inspect_svc(v1_names, collections_path=preferred_path)
+            )
+        except Exception:
+            pass
+
+    if v2_names:
+        from core.v2.services import inspect as v2_inspect
+
+        for n in v2_names:
+            try:
+                collections.append(v2_inspect(n, collections_dir=preferred_dir))
+            except Exception:
+                continue
+
+    # Preserve directory-sorted order (v1 inspect sorts by mtime; restabilize
+    # so mixed lists render alphabetically, matching the directory walk).
+    collections.sort(key=lambda c: c.name)
+    return collections
 
 
 def __getattr__(name: str):

--- a/apps/indexed/src/indexed/knowledge/commands/inspect.py
+++ b/apps/indexed/src/indexed/knowledge/commands/inspect.py
@@ -22,7 +22,10 @@ from ...utils.components import (
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path as _Path
+
     from core.v1.engine.services import CollectionInfo
+    from core.v1.engine.services.models import CollectionStatus
 
 # ---- Use format_size and format_time from @format.py ----
 from ...utils.format import format_size, format_time
@@ -179,6 +182,39 @@ def format_collections_json(collections: List["CollectionInfo"]) -> None:
     print_json(output)
 
 
+def _v2_status_to_info(
+    status: "CollectionStatus", collections_dir: "_Path"
+) -> "CollectionInfo":
+    """Adapt v2 CollectionStatus → CollectionInfo for the shared formatter."""
+    from core.v1.engine.services.models import CollectionInfo
+    from core.v2.storage import get_collection_path, read_manifest
+
+    try:
+        manifest = read_manifest(status.name, collections_dir)
+        created_time = manifest.get("created_time", "")
+    except Exception:
+        created_time = ""
+
+    col_path = get_collection_path(status.name, collections_dir)
+    disk_size = (
+        sum(f.stat().st_size for f in col_path.rglob("*") if f.is_file())
+        if col_path.exists()
+        else 0
+    )
+
+    return CollectionInfo(
+        name=status.name,
+        source_type=status.source_type,
+        number_of_documents=status.number_of_documents,
+        number_of_chunks=status.number_of_chunks,
+        disk_size_bytes=disk_size,
+        index_size_bytes=status.index_size or disk_size,
+        created_time=created_time,
+        updated_time=status.updated_time,
+        indexers=status.indexers,
+    )
+
+
 # ---- END FORMATTER LOGIC ----
 
 
@@ -278,7 +314,10 @@ def inspect_collections(
             if active_engine == "v2":
                 from core.v2.services import status as v2_status
 
-                collections = v2_status(collections_dir=preferred_dir)
+                v2_statuses = v2_status(collections_dir=preferred_dir)
+                collections = [
+                    _v2_status_to_info(s, preferred_dir) for s in v2_statuses
+                ]
             else:
                 collections = inspect_svc(collections_path=preferred_path)
         else:

--- a/apps/indexed/src/indexed/knowledge/commands/remove.py
+++ b/apps/indexed/src/indexed/knowledge/commands/remove.py
@@ -72,7 +72,6 @@ def remove(
     from pathlib import Path
     from ...utils.storage_info import resolve_preferred_collections_path
 
-    active_engine = get_effective_engine(engine)
     index_svc = this_module.Index
     inspect_svc = this_module.inspect
     setup_root_logger_svc = this_module.setup_root_logger
@@ -83,6 +82,10 @@ def remove(
 
     preferred_path = str(resolve_preferred_collections_path())
     preferred_dir = Path(preferred_path)
+
+    active_engine = get_effective_engine(
+        engine, collection=collection, collections_path=preferred_path
+    )
 
     index = index_svc()
     simple = is_simple_output()

--- a/apps/indexed/src/indexed/knowledge/commands/remove.py
+++ b/apps/indexed/src/indexed/knowledge/commands/remove.py
@@ -72,7 +72,6 @@ def remove(
     from pathlib import Path
     from ...utils.storage_info import resolve_preferred_collections_path
 
-    active_engine = get_effective_engine(engine)
     setup_root_logger_svc = this_module.setup_root_logger
 
     # Setup logging based on options
@@ -81,6 +80,10 @@ def remove(
 
     preferred_path = str(resolve_preferred_collections_path())
     preferred_dir = Path(preferred_path)
+
+    active_engine = get_effective_engine(
+        engine, collection=collection, collections_path=preferred_path
+    )
 
     simple = is_simple_output()
 

--- a/apps/indexed/src/indexed/knowledge/commands/remove.py
+++ b/apps/indexed/src/indexed/knowledge/commands/remove.py
@@ -72,8 +72,7 @@ def remove(
     from pathlib import Path
     from ...utils.storage_info import resolve_preferred_collections_path
 
-    index_svc = this_module.Index
-    inspect_svc = this_module.inspect
+    active_engine = get_effective_engine(engine)
     setup_root_logger_svc = this_module.setup_root_logger
 
     # Setup logging based on options
@@ -83,11 +82,6 @@ def remove(
     preferred_path = str(resolve_preferred_collections_path())
     preferred_dir = Path(preferred_path)
 
-    active_engine = get_effective_engine(
-        engine, collection=collection, collections_path=preferred_path
-    )
-
-    index = index_svc()
     simple = is_simple_output()
 
     # Display storage mode indicator (not in verbose/simple mode, to keep logs clean)
@@ -103,6 +97,7 @@ def remove(
 
         all_collections = v2_status(collections_dir=preferred_dir)
     else:
+        inspect_svc = this_module.inspect
         all_collections = inspect_svc()
 
     if not all_collections:
@@ -138,7 +133,7 @@ def remove(
 
                 v2_clear([collection], collections_dir=preferred_dir)
             else:
-                index.remove(collection)
+                this_module.Index().remove(collection)
             print_json({"status": "removed", "collection": collection})
         except Exception as e:
             print_json({"status": "error", "collection": collection, "error": str(e)})
@@ -191,7 +186,7 @@ def remove(
 
                     v2_clear([collection], collections_dir=preferred_dir)
                 else:
-                    index.remove(collection)
+                    this_module.Index().remove(collection)
         else:
             # Normal mode: phased progress display
             source_type = target_collection.source_type
@@ -205,7 +200,7 @@ def remove(
 
                     v2_clear([collection], collections_dir=preferred_dir)
                 else:
-                    index.remove(collection)
+                    this_module.Index().remove(collection)
                 phased.finish_phase("Removing collection data")
 
         console.print()

--- a/apps/indexed/src/indexed/knowledge/commands/search.py
+++ b/apps/indexed/src/indexed/knowledge/commands/search.py
@@ -526,15 +526,31 @@ def search(
         with create_phased_progress(title=title) as phased:
             for coll_name in collections_to_search:
                 phased.start_phase(f"Searching {coll_name}")
-                result = svc_search(
-                    query,
-                    configs=[search_configs[coll_name]],
-                    max_docs=limit,
-                    max_chunks=limit * 3,
-                    include_matched_chunks=True,
-                    collections_path=preferred_path,
-                )
-                results.update(result)
+                if active_engine == "v2":
+                    raw = svc_search_v2(
+                        query,
+                        configs=[
+                            source_config_class(
+                                name=coll_name, type="localFiles", base_url_or_path=""
+                            )
+                        ],
+                        max_docs=_v2_search_cfg.max_docs,
+                        max_chunks=_v2_search_cfg.max_chunks,
+                        include_matched_chunks=_v2_search_cfg.include_matched_chunks,
+                        embed_model_name=_v2_embed_cfg.model_name,
+                        collections_dir=preferred_dir,
+                    )
+                    results.update(_normalize_v2_search(raw))
+                else:
+                    result = svc_search(
+                        query,
+                        configs=[search_configs[coll_name]],
+                        max_docs=limit,
+                        max_chunks=limit * 3,
+                        include_matched_chunks=True,
+                        collections_path=preferred_path,
+                    )
+                    results.update(result)
                 phased.finish_phase(f"Searching {coll_name}")
 
     # Format and display results

--- a/apps/indexed/src/indexed/knowledge/commands/search.py
+++ b/apps/indexed/src/indexed/knowledge/commands/search.py
@@ -378,8 +378,6 @@ def search(
     from . import search as this_module
     from ...services.engine_router import get_effective_engine
 
-    active_engine = get_effective_engine(engine)
-
     index_class = this_module.Index
     svc_search = this_module.svc_search
     source_config_class = this_module.SourceConfig
@@ -398,6 +396,10 @@ def search(
     from ...utils.storage_info import resolve_preferred_collections_path
 
     preferred_path = str(resolve_preferred_collections_path())
+
+    active_engine = get_effective_engine(
+        engine, collection=collection, collections_path=preferred_path
+    )
 
     # Display storage mode indicator (not in verbose/simple mode, to keep logs clean)
     if not is_verbose_mode() and not simple:
@@ -476,6 +478,16 @@ def search(
     if active_engine != "v2":
         for coll_name in collections_to_search:
             coll_status = status_svc([coll_name], collections_path=preferred_path)[0]
+            if not coll_status.indexers:
+                # Defense-in-depth: auto-detection should have routed v2 collections
+                # to the v2 path; reaching this branch means a v1 lookup yielded no
+                # indexer metadata (e.g. forced --engine v1 against a v2 layout).
+                print_error(
+                    f"Collection '{coll_name}' has no indexer metadata. "
+                    "If this is a v2 collection, pass --engine v2 or set "
+                    "[general] engine = 'v2' in your config."
+                )
+                raise typer.Exit(1)
             search_configs[coll_name] = source_config_class(
                 name=coll_name,
                 type="localFiles",

--- a/apps/indexed/src/indexed/knowledge/commands/update.py
+++ b/apps/indexed/src/indexed/knowledge/commands/update.py
@@ -252,8 +252,6 @@ def update(
     from pathlib import Path
     from ...utils.storage_info import resolve_preferred_collections_path
 
-    active_engine = get_effective_engine(engine)
-
     update_service = this_module.update_service
     source_config_class = this_module.SourceConfig
     svc_status = this_module.svc_status
@@ -266,6 +264,11 @@ def update(
 
     preferred_path = str(resolve_preferred_collections_path())
     preferred_dir = Path(preferred_path)
+
+    def _engine_for(coll_name: str) -> str:
+        return get_effective_engine(
+            engine, collection=coll_name, collections_path=preferred_path
+        )
 
     # Initialize ConfigService and check if config existed before
     config_service = ConfigService.instance()
@@ -281,14 +284,26 @@ def update(
 
     # Determine collections to update
     if collection is None:
-        # Update all collections
-        if active_engine == "v2":
-            from core.v2.services import status as v2_status
+        # Enumerate all collections regardless of engine by scanning the
+        # storage dir for manifests. This lets a mixed-engine repo update
+        # both v1 and v2 collections in one command. When the dir is missing
+        # (e.g. CI/test env), fall back to the v1 status service so existing
+        # mocks keep working.
+        collections_to_update: list[str] = []
+        if preferred_dir.exists():
+            collections_to_update = sorted(
+                d.name
+                for d in preferred_dir.iterdir()
+                if d.is_dir() and (d / "manifest.json").exists()
+            )
+        if not collections_to_update:
+            try:
+                fallback_statuses = svc_status()
+                collections_to_update = [s.name for s in fallback_statuses]
+            except Exception:
+                collections_to_update = []
 
-            all_statuses = v2_status(collections_dir=preferred_dir)
-        else:
-            all_statuses = svc_status()
-        if not all_statuses:
+        if not collections_to_update:
             if simple:
                 print_json({"error": "No collections found"})
                 return
@@ -300,14 +315,14 @@ def update(
             )
             return
 
-        collections_to_update = [s.name for s in all_statuses]
         if not simple and len(collections_to_update) > 1:
             names = ", ".join(f'"{n}"' for n in collections_to_update)
             console.print(
                 f"\n[{get_heading_style()}]Updating {len(collections_to_update)} Collections: {names}[/{get_heading_style()}]"
             )
     else:
-        # Update specific collection
+        # Update specific collection — auto-detect its engine
+        active_engine = _engine_for(collection)
         if active_engine == "v2":
             from core.v2.services import status as v2_status
 
@@ -325,9 +340,10 @@ def update(
 
         collections_to_update = [collection]
 
-    # Capture before state for all collections
+    # Capture before state for all collections (per-collection engine)
     before_data = {}
     for coll_name in collections_to_update:
+        active_engine = _engine_for(coll_name)
         if active_engine == "v2":
             from core.v2.services import inspect as v2_inspect
 
@@ -363,6 +379,9 @@ def update(
     chunks_delta = 0
 
     for coll_name in collections_to_update:
+        # Per-collection engine: re-detect each iteration so a mixed-engine
+        # repo routes each name to the engine that actually produced it.
+        active_engine = _engine_for(coll_name)
         # Get collection status to build proper SourceConfig / connector
         if active_engine == "v2":
             from core.v2.services import status as v2_status_loop
@@ -450,8 +469,18 @@ def update(
                         break
         else:
             if not coll_status.indexers:
-                print_error(f"Collection '{coll_name}' has no indexers configured")
-                continue
+                # Auto-detection should have routed v2 collections to the v2
+                # path above. Reaching this means a v1 lookup found no indexer
+                # metadata (e.g. forced --engine v1 against a v2 layout, or a
+                # corrupt manifest) — fail loudly with operator guidance
+                # instead of silently skipping.
+                print_error(
+                    f"Collection '{coll_name}' has no indexer metadata. "
+                    "The on-disk layout does not match v1 expectations. "
+                    "If this is a v2 collection, pass --engine v2 or set "
+                    "[general] engine = 'v2' in your config."
+                )
+                raise typer.Exit(1)
 
             source_config = source_config_class(
                 name=coll_name,
@@ -543,9 +572,19 @@ def update(
     # Simple output mode: JSON status
     if simple:
         for coll_name in successfully_updated:
-            inspect_result = inspect_svc([coll_name])
-            if inspect_result:
-                after_info = inspect_result[0]
+            after_info = None
+            if _engine_for(coll_name) == "v2":
+                from core.v2.services import inspect as v2_inspect
+
+                try:
+                    after_info = v2_inspect(coll_name, collections_dir=preferred_dir)
+                except Exception:
+                    after_info = None
+            else:
+                inspect_result = inspect_svc([coll_name])
+                if inspect_result:
+                    after_info = inspect_result[0]
+            if after_info is not None:
                 before_info = before_data[coll_name]
                 total_docs += after_info.number_of_documents
                 total_chunks += after_info.number_of_chunks

--- a/apps/indexed/src/indexed/mcp/cli.py
+++ b/apps/indexed/src/indexed/mcp/cli.py
@@ -165,7 +165,6 @@ def run_impl(
             host=host,
             port=port,
             log_level=log_level,
-            json_logs=False,
         )
 
 

--- a/apps/indexed/src/indexed/mcp/config.py
+++ b/apps/indexed/src/indexed/mcp/config.py
@@ -13,3 +13,38 @@ def resolve_config(ctx: Optional[Any], key: str, loader: Callable[[], Any]) -> A
         except (AttributeError, TypeError):
             pass
     return loader()
+
+
+def resolve_engine_for_collection(
+    collection: str,
+    ctx: Optional[Any],
+    fallback_loader: Callable[[], str],
+) -> str:
+    """Resolve the engine for a collection-scoped MCP call.
+
+    Auto-detects the engine from the collection's on-disk ``manifest.json``
+    and falls back to the lifespan-cached config default (or the loader)
+    when no manifest is found.
+
+    Args:
+        collection: Target collection name (must be supplied for detection).
+        ctx: FastMCP request context (for lifespan-cached config default).
+        fallback_loader: Callable returning the config default engine when
+            ``ctx`` has no lifespan state.
+
+    Returns:
+        ``"v1"`` or ``"v2"``.
+    """
+    from ..services.engine_router import detect_collection_engine
+    from ..utils.storage_info import resolve_preferred_collections_path
+
+    if collection:
+        try:
+            preferred_path = str(resolve_preferred_collections_path())
+            detected = detect_collection_engine(collection, preferred_path)
+            if detected is not None:
+                return detected
+        except Exception:
+            pass
+
+    return str(resolve_config(ctx, "engine", fallback_loader))

--- a/apps/indexed/src/indexed/mcp/resources.py
+++ b/apps/indexed/src/indexed/mcp/resources.py
@@ -20,7 +20,10 @@ from fastmcp import Context
 
 from core.v1.engine.services import status as svc_status
 
-from .config import resolve_config as _resolve_config
+from .config import (
+    resolve_config as _resolve_config,
+    resolve_engine_for_collection as _resolve_engine_for_collection,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -95,7 +98,7 @@ def register_resources(
     )
     def collection_status(name: str, ctx: Optional[Context] = None) -> Dict[str, Any]:
         mcp_cfg = _resolve_config(ctx, "mcp_config", get_mcp_config)
-        engine = _resolve_config(ctx, "engine", get_engine)
+        engine = _resolve_engine_for_collection(name, ctx, get_engine)
 
         try:
             if engine == "v2":

--- a/apps/indexed/src/indexed/mcp/tools.py
+++ b/apps/indexed/src/indexed/mcp/tools.py
@@ -10,7 +10,10 @@ from core.v1.engine.services import (
     status as svc_status,
 )
 
-from .config import resolve_config as _resolve_config
+from .config import (
+    resolve_config as _resolve_config,
+    resolve_engine_for_collection as _resolve_engine_for_collection,
+)
 from .formatting import format_search_results_for_llm
 
 
@@ -108,7 +111,7 @@ def register_tools(
             dict: LLM-friendly search results with the same structure as search() tool
         """
         search_cfg = _resolve_config(ctx, "search_config", get_search_config)
-        engine = _resolve_config(ctx, "engine", get_engine)
+        engine = _resolve_engine_for_collection(collection, ctx, get_engine)
 
         try:
             if engine == "v2":

--- a/apps/indexed/src/indexed/services/engine_router.py
+++ b/apps/indexed/src/indexed/services/engine_router.py
@@ -3,13 +3,16 @@
 Resolution order (highest priority first):
 1. Per-command ``--engine`` flag (passed as ``command_engine`` arg)
 2. Root callback ``--engine`` flag stored in ``ctx.obj["engine"]``
-3. ``[general] engine`` key in config.toml
-4. Default: ``"v1"``
+3. On-disk ``manifest.json`` for the named collection (auto-detect)
+4. ``[general] engine`` key in config.toml
+5. Default: ``"v1"``
 """
 
 from __future__ import annotations
 
-from typing import Any, Literal, Optional
+import json
+from pathlib import Path
+from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
@@ -23,11 +26,71 @@ class GeneralConfig(BaseModel):
     )
 
 
-def get_effective_engine(command_engine: Optional[str] = None) -> str:
-    """Resolve the active engine for the current call.
+def detect_collection_engine(
+    collection: str,
+    collections_path: Union[str, Path],
+) -> Optional[Literal["v1", "v2"]]:
+    """Classify a collection's engine by reading its on-disk manifest.
+
+    Both engines persist ``<collections_path>/<collection>/manifest.json``.
+    Schema differences:
+
+    - v1 manifest (writer:
+      ``packages/indexed-core/src/core/v1/engine/core/documents_collection_creator.py``):
+      camelCase keys (``collectionName``, ``numberOfDocuments``, ``indexers``).
+      No ``"version"`` key.
+    - v2 manifest (writer: ``packages/indexed-core/src/core/v2/storage.py``):
+      snake_case keys (``name``, ``num_documents``, ``num_chunks``) plus an
+      explicit ``"version": "2.0"`` field.
+
+    Detection rule: a parsed manifest dict whose ``"version"`` value starts with
+    ``"2"`` is ``"v2"``; any other dict is ``"v1"``. Missing files, malformed
+    JSON, and non-dict payloads return ``None`` so callers fall back to the
+    configured default.
 
     Args:
-        command_engine: Per-command ``--engine`` flag value (highest priority).
+        collection: Collection directory name.
+        collections_path: Root directory containing collection subdirectories.
+
+    Returns:
+        ``"v1"``, ``"v2"``, or ``None`` if the manifest is missing/unreadable.
+    """
+    manifest_path = Path(collections_path) / collection / "manifest.json"
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, ValueError):
+        return None
+
+    if not isinstance(payload, dict):
+        return None
+
+    version = payload.get("version")
+    if isinstance(version, str) and version.startswith("2"):
+        return "v2"
+    return "v1"
+
+
+def get_effective_engine(
+    command_engine: Optional[str] = None,
+    *,
+    collection: Optional[str] = None,
+    collections_path: Optional[Union[str, Path]] = None,
+) -> str:
+    """Resolve the active engine for the current call.
+
+    Resolution order (highest priority first):
+    1. ``command_engine`` (per-command ``--engine`` flag).
+    2. ``ctx.obj["engine"]`` (root callback ``--engine`` flag).
+    3. Manifest auto-detection — only when both ``collection`` and
+       ``collections_path`` are supplied.
+    4. ``[general] engine`` from ``config.toml``.
+    5. Default: ``"v1"``.
+
+    Args:
+        command_engine: Per-command ``--engine`` flag value.
+        collection: Optional collection name to auto-detect from disk.
+        collections_path: Root directory containing collection subdirectories.
+            Required alongside ``collection`` for manifest detection.
 
     Returns:
         ``"v1"`` or ``"v2"``.
@@ -45,6 +108,12 @@ def get_effective_engine(command_engine: Optional[str] = None) -> str:
             return str(root_engine)
     except (RuntimeError, AttributeError):
         pass  # No active Typer context (e.g., during unit tests)
+
+    # Auto-detect from on-disk manifest when a target collection is named
+    if collection and collections_path is not None:
+        detected = detect_collection_engine(collection, collections_path)
+        if detected is not None:
+            return detected
 
     # Fall back to [general] engine in config
     try:

--- a/apps/indexed/src/indexed/services/engine_router.py
+++ b/apps/indexed/src/indexed/services/engine_router.py
@@ -16,6 +16,20 @@ from typing import Any, Literal, Optional, Union
 
 from pydantic import BaseModel, Field
 
+VALID_ENGINES: frozenset[str] = frozenset({"v1", "v2"})
+
+
+def normalize_engine(value: Any) -> Optional[str]:
+    """Lowercase a candidate engine value and validate it against ``VALID_ENGINES``.
+
+    Returns the normalized string if valid, ``None`` otherwise. Non-string
+    inputs (e.g., Typer ``OptionInfo`` sentinels) return ``None``.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    normalized = value.lower()
+    return normalized if normalized in VALID_ENGINES else None
+
 
 class GeneralConfig(BaseModel):
     """Top-level [general] section of config.toml."""
@@ -95,17 +109,18 @@ def get_effective_engine(
     Returns:
         ``"v1"`` or ``"v2"``.
     """
-    if command_engine and isinstance(command_engine, str):
-        return command_engine.lower()
+    cmd = normalize_engine(command_engine)
+    if cmd is not None:
+        return cmd
 
     # Root callback flag stored on Typer context
     try:
         import click
 
         ctx = click.get_current_context()
-        root_engine: Any = (ctx.obj or {}).get("engine")
-        if root_engine:
-            return str(root_engine)
+        root_engine = normalize_engine((ctx.obj or {}).get("engine"))
+        if root_engine is not None:
+            return root_engine
     except (RuntimeError, AttributeError):
         pass  # No active Typer context (e.g., during unit tests)
 
@@ -122,7 +137,9 @@ def get_effective_engine(
         config = ConfigService.instance()
         provider = config.bind()
         general = provider.get(GeneralConfig)
-        return str(general.engine)
+        cfg_engine = normalize_engine(general.engine)
+        if cfg_engine is not None:
+            return cfg_engine
     except Exception:
         pass
 

--- a/packages/indexed-config/src/indexed_config/service.py
+++ b/packages/indexed-config/src/indexed_config/service.py
@@ -157,6 +157,13 @@ class ConfigService:
         for path, spec in self._registry.specs.items():
             payload = get_by_path(raw, path, default=None)
             if payload in (None, {}):
+                # No user config under this namespace. Try defaults; if the
+                # spec has required fields, Pydantic raises and we skip.
+                try:
+                    instances[spec] = spec.model_validate({})  # type: ignore[arg-type]
+                    path_to_type[path] = spec
+                except ValidationError:
+                    pass
                 continue
             try:
                 instances[spec] = spec.model_validate(payload)  # type: ignore[arg-type]

--- a/packages/indexed-core/src/core/v2/__init__.py
+++ b/packages/indexed-core/src/core/v2/__init__.py
@@ -12,8 +12,21 @@ Config registration is explicit — call :func:`core.v2.config.register_config`
 from app startup. This module has NO import-time side effects.
 """
 
-from .index import Index, IndexConfig
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .index import Index, IndexConfig
 
 __version__ = "2.0.0"
 
-__all__ = ["Index", "IndexConfig", "__version__"]
+__all__ = ["Index", "IndexConfig"]
+
+
+def __getattr__(name: str) -> Any:
+    if name in ("Index", "IndexConfig"):
+        from . import index as _index_mod
+
+        return getattr(_index_mod, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/indexed-core/src/core/v2/config.py
+++ b/packages/indexed-core/src/core/v2/config.py
@@ -6,13 +6,15 @@ Registration is explicit via :func:`register_config` — never at import time.
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Literal, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class CoreV2EmbeddingConfig(BaseModel):
     """Embedding generation configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     model_name: str = Field(
         default="all-MiniLM-L6-v2",
@@ -25,6 +27,8 @@ class CoreV2EmbeddingConfig(BaseModel):
 
 class CoreV2IndexingConfig(BaseModel):
     """Indexing pipeline configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     chunk_size: int = Field(
         default=512, ge=1, le=4096, description="Size of text chunks"
@@ -50,9 +54,11 @@ class CoreV2IndexingConfig(BaseModel):
 class CoreV2StorageConfig(BaseModel):
     """Vector storage configuration."""
 
-    vector_store: str = Field(
+    model_config = ConfigDict(extra="forbid")
+
+    vector_store: Literal["faiss", "chroma", "qdrant"] = Field(
         default="faiss",
-        description="Vector store backend (faiss, chroma, qdrant)",
+        description="Vector store backend (only 'faiss' is implemented)",
     )
     persistence_enabled: bool = Field(
         default=True, description="Enable persistence to disk"
@@ -61,6 +67,8 @@ class CoreV2StorageConfig(BaseModel):
 
 class CoreV2SearchConfig(BaseModel):
     """Search configuration."""
+
+    model_config = ConfigDict(extra="forbid")
 
     max_docs: int = Field(
         default=10, ge=1, le=100, description="Maximum documents to return"

--- a/packages/indexed-core/src/core/v2/embedding.py
+++ b/packages/indexed-core/src/core/v2/embedding.py
@@ -6,6 +6,7 @@ The ONNX backend is preferred for faster inference, with PyTorch fallback.
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Optional
 
 from .errors import EmbeddingError
@@ -15,6 +16,14 @@ if TYPE_CHECKING:
 
 _cached_model: Optional["HuggingFaceEmbedding"] = None
 _cached_model_name: Optional[str] = None
+_cache_lock = threading.Lock()
+
+
+def _resolve_repo_id(model_name: str) -> str:
+    """Prefix bare model names with the canonical sentence-transformers org."""
+    return (
+        f"sentence-transformers/{model_name}" if "/" not in model_name else model_name
+    )
 
 
 def get_embed_model(
@@ -22,12 +31,13 @@ def get_embed_model(
 ) -> "HuggingFaceEmbedding":
     """Return a HuggingFace embedding model, lazily loaded and cached.
 
-    The model is cached for the process lifetime. Subsequent calls with
-    the same ``model_name`` return the cached instance.
+    The model is cached for the process lifetime, keyed on the resolved
+    HuggingFace repo id so ``"all-MiniLM-L6-v2"`` and
+    ``"sentence-transformers/all-MiniLM-L6-v2"`` share one cache entry.
 
     Args:
-        model_name: HuggingFace model name (e.g. ``all-MiniLM-L6-v2``).
-            If no ``/`` is present, ``sentence-transformers/`` is prepended.
+        model_name: HuggingFace model name. If no ``/`` is present,
+            ``sentence-transformers/`` is prepended to form the repo id.
 
     Returns:
         A :class:`HuggingFaceEmbedding` instance usable by LlamaIndex.
@@ -37,28 +47,30 @@ def get_embed_model(
     """
     global _cached_model, _cached_model_name  # noqa: PLW0603
 
-    if _cached_model is not None and _cached_model_name == model_name:
+    repo_id = _resolve_repo_id(model_name)
+
+    if _cached_model is not None and _cached_model_name == repo_id:
         return _cached_model
 
-    repo_id = (
-        f"sentence-transformers/{model_name}" if "/" not in model_name else model_name
-    )
+    with _cache_lock:
+        if _cached_model is not None and _cached_model_name == repo_id:
+            return _cached_model
 
-    try:
-        from llama_index.embeddings.huggingface import HuggingFaceEmbedding
-    except ImportError as exc:
-        msg = (
-            "llama-index-embeddings-huggingface is required for v2. "
-            "Install it with: uv add llama-index-embeddings-huggingface"
-        )
-        raise EmbeddingError(msg) from exc
+        try:
+            from llama_index.embeddings.huggingface import HuggingFaceEmbedding
+        except ImportError as exc:
+            msg = (
+                "llama-index-embeddings-huggingface is required for v2. "
+                "Install it with: uv add llama-index-embeddings-huggingface"
+            )
+            raise EmbeddingError(msg) from exc
 
-    try:
-        _cached_model = HuggingFaceEmbedding(model_name=repo_id)
-        _cached_model_name = model_name
-    except Exception as exc:
-        msg = f"Failed to load embedding model '{repo_id}': {exc}"
-        raise EmbeddingError(msg) from exc
+        try:
+            _cached_model = HuggingFaceEmbedding(model_name=repo_id)
+            _cached_model_name = repo_id
+        except Exception as exc:
+            msg = f"Failed to load embedding model '{repo_id}': {exc}"
+            raise EmbeddingError(msg) from exc
 
     return _cached_model
 
@@ -66,5 +78,6 @@ def get_embed_model(
 def reset_cache() -> None:
     """Clear the cached embedding model. Useful for testing."""
     global _cached_model, _cached_model_name  # noqa: PLW0603
-    _cached_model = None
-    _cached_model_name = None
+    with _cache_lock:
+        _cached_model = None
+        _cached_model_name = None

--- a/packages/indexed-core/src/core/v2/index.py
+++ b/packages/indexed-core/src/core/v2/index.py
@@ -105,23 +105,27 @@ class Index:
         Args:
             collection: Specific collection name or None for all tracked.
         """
+        from .errors import CollectionNotFoundError
         from .services.collection_service import update as _update
 
-        if collection and collection in self._collections:
+        if collection is not None:
+            if collection not in self._collections:
+                raise CollectionNotFoundError(collection)
             _update(
                 collection,
                 self._collections[collection],
                 embed_model_name=self.config.embed_model_name,
                 store_type=self.config.vector_store_type,
             )
-        elif collection is None:
-            for name, conn in self._collections.items():
-                _update(
-                    name,
-                    conn,
-                    embed_model_name=self.config.embed_model_name,
-                    store_type=self.config.vector_store_type,
-                )
+            return
+
+        for name, conn in self._collections.items():
+            _update(
+                name,
+                conn,
+                embed_model_name=self.config.embed_model_name,
+                store_type=self.config.vector_store_type,
+            )
 
     def status(self, collection: Optional[str] = None) -> Any:
         """Get status for collections.

--- a/packages/indexed-core/src/core/v2/retrieval.py
+++ b/packages/indexed-core/src/core/v2/retrieval.py
@@ -33,7 +33,7 @@ def search_collection(
     Returns:
         Dict with ``collectionName`` and ``results`` keys.
     """
-    from llama_index.core import VectorStoreIndex
+    from llama_index.core import load_index_from_storage
 
     from .embedding import get_embed_model
     from .storage import load_storage_context
@@ -41,9 +41,7 @@ def search_collection(
     embed_model = get_embed_model(embed_model_name)
 
     storage_context = load_storage_context(collection_name, collections_dir)
-    index = VectorStoreIndex.from_storage_context(
-        storage_context, embed_model=embed_model
-    )
+    index = load_index_from_storage(storage_context, embed_model=embed_model)
 
     retriever = index.as_retriever(similarity_top_k=similarity_top_k)
     retrieved_nodes = retriever.retrieve(query)

--- a/packages/indexed-core/src/core/v2/services/__init__.py
+++ b/packages/indexed-core/src/core/v2/services/__init__.py
@@ -50,9 +50,7 @@ def __getattr__(name: str) -> Any:
     try:
         module_name, attr_name = _SOURCES[name]
     except KeyError as exc:
-        raise AttributeError(
-            f"module {__name__!r} has no attribute {name!r}"
-        ) from exc
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
     from importlib import import_module
 
     module = import_module(f"{__name__}.{module_name}")

--- a/packages/indexed-core/src/core/v2/services/__init__.py
+++ b/packages/indexed-core/src/core/v2/services/__init__.py
@@ -1,9 +1,21 @@
-"""V2 service layer — orchestration between CLI/MCP and domain modules."""
+"""V2 service layer — orchestration between CLI/MCP and domain modules.
 
-from .collection_service import clear, create, update
-from .inspect_service import inspect, status
-from .models import CollectionInfo, CollectionStatus, SearchResult, SourceConfig
-from .search_service import SearchService, search
+Re-exports are lazy: importing this module does not pull in the heavy
+LlamaIndex / HuggingFace stack. Symbols resolve on first attribute access.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .models import (
+        CollectionInfo,
+        CollectionStatus,
+        SearchResult,
+        SourceConfig,
+    )
+    from .search_service import SearchService
 
 __all__ = [
     "CollectionInfo",
@@ -18,3 +30,30 @@ __all__ = [
     "status",
     "update",
 ]
+
+_SOURCES = {
+    "clear": ("collection_service", "clear"),
+    "create": ("collection_service", "create"),
+    "update": ("collection_service", "update"),
+    "inspect": ("inspect_service", "inspect"),
+    "status": ("inspect_service", "status"),
+    "SearchService": ("search_service", "SearchService"),
+    "search": ("search_service", "search"),
+    "CollectionInfo": ("models", "CollectionInfo"),
+    "CollectionStatus": ("models", "CollectionStatus"),
+    "SearchResult": ("models", "SearchResult"),
+    "SourceConfig": ("models", "SourceConfig"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    try:
+        module_name, attr_name = _SOURCES[name]
+    except KeyError as exc:
+        raise AttributeError(
+            f"module {__name__!r} has no attribute {name!r}"
+        ) from exc
+    from importlib import import_module
+
+    module = import_module(f"{__name__}.{module_name}")
+    return getattr(module, attr_name)

--- a/packages/indexed-core/src/core/v2/storage.py
+++ b/packages/indexed-core/src/core/v2/storage.py
@@ -30,13 +30,36 @@ def get_collections_dir() -> Path:
         return Path.home() / ".indexed" / "data" / "collections"
 
 
+def _validate_collection_name(name: str) -> None:
+    """Reject names that could escape the collections root."""
+    if not name or not name.strip():
+        raise ValueError("Collection name must not be empty or whitespace")
+    if ".." in name:
+        raise ValueError(f"Collection name must not contain '..': {name!r}")
+    candidate = Path(name)
+    if candidate.is_absolute():
+        raise ValueError(f"Collection name must not be an absolute path: {name!r}")
+    if len(candidate.parts) != 1:
+        raise ValueError(f"Collection name must be a single path segment: {name!r}")
+
+
 def get_collection_path(
     collection_name: str,
     collections_dir: Optional[Path] = None,
 ) -> Path:
-    """Resolve the on-disk path for a collection."""
-    base = collections_dir or get_collections_dir()
-    return base / collection_name
+    """Resolve the on-disk path for a collection.
+
+    Validates the name so callers cannot escape ``collections_dir`` via
+    ``..``, absolute paths, or multi-segment names.
+    """
+    _validate_collection_name(collection_name)
+    base = (collections_dir or get_collections_dir()).resolve()
+    resolved = (base / collection_name).resolve()
+    if resolved.parent != base:
+        raise ValueError(
+            f"Collection name resolves outside collections root: {collection_name!r}"
+        )
+    return resolved
 
 
 def create_storage_context(
@@ -123,7 +146,9 @@ def write_manifest(
         get_collection_path(collection_name, collections_dir) / "manifest.json"
     )
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
-    manifest_path.write_text(json.dumps(manifest, indent=2))
+    tmp_path = manifest_path.with_name(manifest_path.name + ".tmp")
+    tmp_path.write_text(json.dumps(manifest, indent=2))
+    tmp_path.replace(manifest_path)
 
     return manifest
 

--- a/packages/indexed-core/src/core/v2/vector_store.py
+++ b/packages/indexed-core/src/core/v2/vector_store.py
@@ -51,5 +51,9 @@ def _create_faiss_store(
         )
         raise VectorStoreError(msg) from exc
 
-    faiss_index = faiss.IndexFlatL2(embed_dim)
-    return FaissVectorStore(faiss_index=faiss_index)
+    try:
+        faiss_index = faiss.IndexFlatL2(embed_dim)
+        return FaissVectorStore(faiss_index=faiss_index)
+    except Exception as exc:
+        msg = f"Failed to create FAISS vector store: {exc}"
+        raise VectorStoreError(msg) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ markers = [
     "benchmark: marks benchmark tests",
     "connectors: marks connector functionality tests",
     "indexed: marks main app integration tests",
+    "requires_embedding_model: marks e2e tests requiring the real HuggingFace embedding model in cache",
 ]
 addopts = [
     "--strict-markers",

--- a/tests/benchmarks/test_e2e_performance.py
+++ b/tests/benchmarks/test_e2e_performance.py
@@ -86,11 +86,22 @@ def benchmark_docs(tmp_path_factory) -> Path:
 
 @pytest.fixture(scope="module")
 def benchmark_workspace(tmp_path_factory) -> Path:
-    """Create a temp workspace with .indexed/ for local collection storage."""
+    """Create a temp workspace with .indexed/ for local collection storage.
+
+    Seeds v2 config sections so `ConfigService.bind()` materializes the v2
+    specs — without these, `provider.get(CoreV2EmbeddingConfig)` raises
+    KeyError because `bind()` skips empty payloads.
+    """
     workspace = tmp_path_factory.mktemp("benchmark_workspace")
     indexed_dir = workspace / ".indexed"
     indexed_dir.mkdir()
-    (indexed_dir / "config.toml").touch()
+    (indexed_dir / "config.toml").write_text(
+        '[core.v2.embedding]\nmodel_name = "all-MiniLM-L6-v2"\n'
+        "[core.v2.indexing]\nchunk_size = 512\n"
+        '[core.v2.storage]\nvector_store = "faiss"\n'
+        "[core.v2.search]\nmax_docs = 10\n",
+        encoding="utf-8",
+    )
     return workspace
 
 
@@ -392,14 +403,14 @@ def test_e2e_search_collection_v2(
             result = runner.invoke(
                 app,
                 [
+                    "--engine",
+                    "v2",
+                    "--local",
                     "index",
                     "search",
                     "indexed collections engine",
                     "--collection",
                     created_collection_v2,
-                    "--engine",
-                    "v2",
-                    "--local",
                     "--compact",
                 ],
             )

--- a/tests/system/_e2e/conftest.py
+++ b/tests/system/_e2e/conftest.py
@@ -73,9 +73,28 @@ def e2e_docs(tmp_path_factory: pytest.TempPathFactory) -> Path:
 def e2e_workspace(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Generator[Path, None, None]:
-    """Provide an isolated workspace with `.indexed/` for local-mode storage."""
+    """Provide an isolated workspace with `.indexed/` for local-mode storage.
+
+    Seeds `config.toml` with explicit v2 sections so `ConfigService.bind()`
+    instantiates the v2 specs (the bind loop skips specs whose payload is
+    ``None`` or ``{}``, which would otherwise raise ``KeyError`` on every
+    `provider.get(...)` call in the v2 path). Resets the ConfigService
+    singleton so a stale workspace path from a previous module doesn't leak in.
+    """
+    from indexed_config import ConfigService
+
     workspace = tmp_path_factory.mktemp("e2e_workspace")
     indexed_dir = workspace / ".indexed"
     indexed_dir.mkdir()
-    (indexed_dir / "config.toml").touch()
-    yield workspace
+    (indexed_dir / "config.toml").write_text(
+        '[core.v2.embedding]\nmodel_name = "all-MiniLM-L6-v2"\n'
+        "[core.v2.indexing]\nchunk_size = 512\n"
+        '[core.v2.storage]\nvector_store = "faiss"\n'
+        "[core.v2.search]\nmax_docs = 10\n",
+        encoding="utf-8",
+    )
+    ConfigService.reset()
+    try:
+        yield workspace
+    finally:
+        ConfigService.reset()

--- a/tests/system/_e2e/conftest.py
+++ b/tests/system/_e2e/conftest.py
@@ -1,0 +1,81 @@
+"""Shared fixtures for e2e tests that exercise the full embed → index → search pipeline.
+
+These tests require the default HuggingFace embedding model. The session fixture
+below downloads it once if it isn't already cached. Set INDEXED_E2E_OFFLINE=1 (or
+HF_HUB_OFFLINE=1) to skip the entire suite for genuinely offline runs. CI populates
+the cache via a dedicated workflow step before pytest is invoked, so the fixture
+is a no-op there.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+EMBEDDING_MODEL = "all-MiniLM-L6-v2"
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_embedding_model() -> None:
+    """Download the default embedding model once per session if not already cached."""
+    if (
+        os.environ.get("INDEXED_E2E_OFFLINE") == "1"
+        or os.environ.get("HF_HUB_OFFLINE") == "1"
+    ):
+        pytest.skip(
+            "E2E disabled (INDEXED_E2E_OFFLINE=1 or HF_HUB_OFFLINE=1); "
+            "the embedding model would need to be downloaded."
+        )
+
+    from core.v1.engine.indexes.embeddings.model_manager import (
+        ensure_model,
+        is_model_cached,
+    )
+
+    if not is_model_cached(EMBEDDING_MODEL):
+        ensure_model(EMBEDDING_MODEL)
+
+
+@pytest.fixture(scope="module")
+def e2e_docs(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Provide a small markdown corpus, falling back to synthetic docs if repo files are missing."""
+    docs_dir = tmp_path_factory.mktemp("e2e_docs")
+
+    real_docs = [
+        _REPO_ROOT / "README.md",
+        _REPO_ROOT / "docs" / "index.md",
+    ]
+    copied = 0
+    for src in real_docs:
+        if src.exists():
+            shutil.copy2(src, docs_dir / src.name)
+            copied += 1
+
+    if copied == 0:
+        for i in range(3):
+            (docs_dir / f"e2e-test-doc-{i}.md").write_text(
+                f"# E2E Test Document {i}\n\n"
+                f"This document tests the full indexing pipeline. "
+                f"It contains content about semantic search, embeddings, and FAISS. "
+                f"Document number {i} in the e2e test corpus.\n" * 5
+            )
+
+    return docs_dir
+
+
+@pytest.fixture(scope="module")
+def e2e_workspace(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[Path, None, None]:
+    """Provide an isolated workspace with `.indexed/` for local-mode storage."""
+    workspace = tmp_path_factory.mktemp("e2e_workspace")
+    indexed_dir = workspace / ".indexed"
+    indexed_dir.mkdir()
+    (indexed_dir / "config.toml").touch()
+    yield workspace

--- a/tests/system/_e2e/test_e2e_v1_engine.py
+++ b/tests/system/_e2e/test_e2e_v1_engine.py
@@ -60,12 +60,12 @@ class TestV1CreateAndSearch:
             result = runner.invoke(
                 app,
                 [
+                    "--local",
                     "index",
                     "search",
                     "semantic search embeddings",
                     "--collection",
                     "v1-e2e-test",
-                    "--local",
                 ],
             )
         finally:
@@ -81,10 +81,10 @@ class TestV1CreateAndSearch:
             result = runner.invoke(
                 app,
                 [
+                    "--local",
                     "index",
                     "search",
                     "document indexing",
-                    "--local",
                 ],
             )
         finally:
@@ -103,12 +103,12 @@ class TestV1CreateAndSearch:
             result = runner.invoke(
                 app,
                 [
+                    "--local",
                     "index",
                     "search",
                     "indexing pipeline",
                     "--collection",
                     "v1-e2e-test",
-                    "--local",
                 ],
             )
         finally:
@@ -131,7 +131,7 @@ class TestV1Inspect:
             os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
-                ["index", "inspect", "--local"],
+                ["--local", "index", "inspect"],
             )
         finally:
             os.chdir(original_cwd)
@@ -146,7 +146,7 @@ class TestV1Inspect:
             os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
-                ["index", "inspect", "v1-e2e-test", "--local"],
+                ["--local", "index", "inspect", "v1-e2e-test"],
             )
         finally:
             os.chdir(original_cwd)
@@ -167,11 +167,11 @@ class TestV1Remove:
             result = runner.invoke(
                 app,
                 [
+                    "--local",
                     "index",
                     "remove",
                     "v1-e2e-test",
                     "--force",
-                    "--local",
                 ],
             )
         finally:

--- a/tests/system/_e2e/test_e2e_v1_engine.py
+++ b/tests/system/_e2e/test_e2e_v1_engine.py
@@ -1,0 +1,182 @@
+"""End-to-end system tests for the default v1 engine across all CLI commands.
+
+Mirrors the v2 e2e suite to give the v1 path equivalent end-to-end coverage:
+create → search → inspect → remove with the real HuggingFace embedder and FAISS.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from indexed.app import app
+
+
+runner = CliRunner()
+
+
+def _strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+class TestV1CreateAndSearch:
+    """Test the create → search workflow using the default v1 engine."""
+
+    def test_create_files_default_engine(
+        self, e2e_docs: Path, e2e_workspace: Path
+    ) -> None:
+        """indexed index create files (default engine) creates a v1 collection."""
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(e2e_workspace)
+            result = runner.invoke(
+                app,
+                [
+                    "index",
+                    "create",
+                    "files",
+                    "--collection",
+                    "v1-e2e-test",
+                    "--path",
+                    str(e2e_docs),
+                    "--force",
+                    "--local",
+                ],
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        clean = _strip_ansi(result.stdout)
+        assert result.exit_code == 0, f"Create failed: {clean}"
+        assert "v1-e2e-test" in clean
+
+    def test_search_specific_collection(self, e2e_workspace: Path) -> None:
+        """indexed index search returns results from the v1 collection."""
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(e2e_workspace)
+            result = runner.invoke(
+                app,
+                [
+                    "index",
+                    "search",
+                    "semantic search embeddings",
+                    "--collection",
+                    "v1-e2e-test",
+                    "--local",
+                ],
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 0, f"Search failed: {_strip_ansi(result.stdout)}"
+
+    def test_search_all_collections(self, e2e_workspace: Path) -> None:
+        """indexed index search (no --collection) searches all v1 collections."""
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(e2e_workspace)
+            result = runner.invoke(
+                app,
+                [
+                    "index",
+                    "search",
+                    "document indexing",
+                    "--local",
+                ],
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 0, f"Search failed: {_strip_ansi(result.stdout)}"
+
+    def test_simple_output_search(self, e2e_workspace: Path) -> None:
+        """Search in simple-output mode returns parseable JSON."""
+        original_cwd = os.getcwd()
+        from indexed.utils.simple_output import set_simple_output, reset_simple_output
+
+        set_simple_output(True)
+        try:
+            os.chdir(e2e_workspace)
+            result = runner.invoke(
+                app,
+                [
+                    "index",
+                    "search",
+                    "indexing pipeline",
+                    "--collection",
+                    "v1-e2e-test",
+                    "--local",
+                ],
+            )
+        finally:
+            os.chdir(original_cwd)
+            reset_simple_output()
+
+        assert result.exit_code == 0, f"Search failed: {result.stdout}"
+        parsed = json.loads(result.stdout)
+        assert "query" in parsed
+        assert "results" in parsed
+
+
+class TestV1Inspect:
+    """Test the inspect command with the default v1 engine."""
+
+    def test_inspect_all_collections(self, e2e_workspace: Path) -> None:
+        """indexed index inspect lists v1 collections."""
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(e2e_workspace)
+            result = runner.invoke(
+                app,
+                ["index", "inspect", "--local"],
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 0, f"Inspect failed: {_strip_ansi(result.stdout)}"
+        assert "v1-e2e-test" in _strip_ansi(result.stdout)
+
+    def test_inspect_specific_collection(self, e2e_workspace: Path) -> None:
+        """indexed index inspect <name> shows v1 collection details."""
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(e2e_workspace)
+            result = runner.invoke(
+                app,
+                ["index", "inspect", "v1-e2e-test", "--local"],
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        clean = _strip_ansi(result.stdout)
+        assert result.exit_code == 0, f"Inspect specific failed: {clean}"
+        assert "v1-e2e-test" in clean
+
+
+class TestV1Remove:
+    """Test the remove command with the default v1 engine."""
+
+    def test_remove_default_engine(self, e2e_workspace: Path) -> None:
+        """indexed index remove --force removes the v1 collection."""
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(e2e_workspace)
+            result = runner.invoke(
+                app,
+                [
+                    "index",
+                    "remove",
+                    "v1-e2e-test",
+                    "--force",
+                    "--local",
+                ],
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        clean = _strip_ansi(result.stdout)
+        assert result.exit_code == 0, f"Remove failed: {clean}"
+        assert "removed" in clean.lower()

--- a/tests/system/_e2e/test_e2e_v2_engine.py
+++ b/tests/system/_e2e/test_e2e_v2_engine.py
@@ -1,18 +1,15 @@
 """End-to-end system tests for the --engine v2 flag across all CLI commands.
 
 Tests follow the full workflow: create → search → inspect → remove.
-All tests are skipped automatically if the v2 embedding model is not cached locally
-to avoid downloading large model files in CI environments that haven't pre-seeded them.
+The session fixture in `conftest.py` ensures the embedding model is cached
+before any test runs.
 """
 
 import json
 import os
 import re
-import shutil
 from pathlib import Path
-from typing import Generator
 
-import pytest
 from typer.testing import CliRunner
 
 from indexed.app import app
@@ -20,82 +17,21 @@ from indexed.app import app
 
 runner = CliRunner()
 
-_REPO_ROOT = Path(__file__).resolve().parents[2]
-
 
 def _strip_ansi(text: str) -> str:
     return re.sub(r"\x1b\[[0-9;]*m", "", text)
-
-
-def _v2_model_available() -> bool:
-    """Return True only if the v2 embedding model is already cached locally."""
-    try:
-        from core.v1.engine.indexes.embeddings.model_manager import is_model_cached
-
-        # v2 defaults to the same model as v1
-        return is_model_cached("all-MiniLM-L6-v2")
-    except Exception:
-        return False
-
-
-# Skip all tests in this module when the embedding model is not cached.
-pytestmark = pytest.mark.skipif(
-    not _v2_model_available(),
-    reason="v2 embedding model not cached (requires all-MiniLM-L6-v2)",
-)
-
-
-@pytest.fixture(scope="module")
-def v2_docs(tmp_path_factory: pytest.TempPathFactory) -> Path:
-    """Create a small corpus of markdown files for v2 e2e tests."""
-    docs_dir = tmp_path_factory.mktemp("v2_docs")
-
-    # Try to copy real docs from the repo
-    real_docs = [
-        _REPO_ROOT / "README.md",
-        _REPO_ROOT / "docs" / "index.md",
-    ]
-    copied = 0
-    for src in real_docs:
-        if src.exists():
-            shutil.copy2(src, docs_dir / src.name)
-            copied += 1
-
-    # Ensure we always have at least some content
-    if copied == 0:
-        for i in range(3):
-            (docs_dir / f"v2-test-doc-{i}.md").write_text(
-                f"# V2 Test Document {i}\n\n"
-                f"This document tests the v2 engine indexing pipeline. "
-                f"It contains content about semantic search, embeddings, and FAISS. "
-                f"Document number {i} in the v2 test corpus.\n" * 5
-            )
-
-    return docs_dir
-
-
-@pytest.fixture(scope="module")
-def v2_workspace(
-    tmp_path_factory: pytest.TempPathFactory,
-) -> Generator[Path, None, None]:
-    """Create an isolated workspace with .indexed/ for local storage."""
-    workspace = tmp_path_factory.mktemp("v2_workspace")
-    indexed_dir = workspace / ".indexed"
-    indexed_dir.mkdir()
-    (indexed_dir / "config.toml").touch()
-    yield workspace
 
 
 class TestV2CreateAndSearch:
     """Test the create → search workflow using --engine v2."""
 
     def test_create_files_with_engine_v2_flag(
-        self, v2_docs: Path, v2_workspace: Path
+        self, e2e_docs: Path, e2e_workspace: Path
     ) -> None:
         """indexed --engine v2 index create files creates a collection successfully."""
         original_cwd = os.getcwd()
         try:
-            os.chdir(v2_workspace)
+            os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
                 [
@@ -107,7 +43,7 @@ class TestV2CreateAndSearch:
                     "--collection",
                     "v2-e2e-test",
                     "--path",
-                    str(v2_docs),
+                    str(e2e_docs),
                     "--force",
                     "--local",
                 ],
@@ -119,11 +55,11 @@ class TestV2CreateAndSearch:
         assert result.exit_code == 0, f"Create failed: {clean}"
         assert "v2-e2e-test" in clean
 
-    def test_search_with_per_command_engine_v2(self, v2_workspace: Path) -> None:
+    def test_search_with_per_command_engine_v2(self, e2e_workspace: Path) -> None:
         """indexed index search --engine v2 returns results from the v2 collection."""
         original_cwd = os.getcwd()
         try:
-            os.chdir(v2_workspace)
+            os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
                 [
@@ -142,11 +78,11 @@ class TestV2CreateAndSearch:
 
         assert result.exit_code == 0, f"Search failed: {_strip_ansi(result.stdout)}"
 
-    def test_search_all_collections_engine_v2(self, v2_workspace: Path) -> None:
+    def test_search_all_collections_engine_v2(self, e2e_workspace: Path) -> None:
         """indexed index search --engine v2 (no --collection) searches all v2 collections."""
         original_cwd = os.getcwd()
         try:
-            os.chdir(v2_workspace)
+            os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
                 [
@@ -163,14 +99,14 @@ class TestV2CreateAndSearch:
 
         assert result.exit_code == 0, f"Search failed: {_strip_ansi(result.stdout)}"
 
-    def test_simple_output_search_engine_v2(self, v2_workspace: Path) -> None:
+    def test_simple_output_search_engine_v2(self, e2e_workspace: Path) -> None:
         """Search with --engine v2 in simple-output mode returns parseable JSON."""
         original_cwd = os.getcwd()
         from indexed.utils.simple_output import set_simple_output, reset_simple_output
 
         set_simple_output(True)
         try:
-            os.chdir(v2_workspace)
+            os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
                 [
@@ -197,11 +133,11 @@ class TestV2CreateAndSearch:
 class TestV2Inspect:
     """Test the inspect command with --engine v2."""
 
-    def test_inspect_all_collections_engine_v2(self, v2_workspace: Path) -> None:
+    def test_inspect_all_collections_engine_v2(self, e2e_workspace: Path) -> None:
         """indexed index inspect --engine v2 lists v2 collections."""
         original_cwd = os.getcwd()
         try:
-            os.chdir(v2_workspace)
+            os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
                 ["index", "inspect", "--engine", "v2", "--local"],
@@ -212,11 +148,11 @@ class TestV2Inspect:
         assert result.exit_code == 0, f"Inspect failed: {_strip_ansi(result.stdout)}"
         assert "v2-e2e-test" in _strip_ansi(result.stdout)
 
-    def test_inspect_specific_collection_engine_v2(self, v2_workspace: Path) -> None:
+    def test_inspect_specific_collection_engine_v2(self, e2e_workspace: Path) -> None:
         """indexed index inspect <name> --engine v2 shows collection details."""
         original_cwd = os.getcwd()
         try:
-            os.chdir(v2_workspace)
+            os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
                 ["index", "inspect", "v2-e2e-test", "--engine", "v2", "--local"],
@@ -232,11 +168,11 @@ class TestV2Inspect:
 class TestV2Remove:
     """Test the remove command with --engine v2."""
 
-    def test_remove_with_engine_v2(self, v2_workspace: Path) -> None:
+    def test_remove_with_engine_v2(self, e2e_workspace: Path) -> None:
         """indexed index remove --engine v2 --force removes the v2 collection."""
         original_cwd = os.getcwd()
         try:
-            os.chdir(v2_workspace)
+            os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
                 [

--- a/tests/system/_e2e/test_e2e_v2_engine.py
+++ b/tests/system/_e2e/test_e2e_v2_engine.py
@@ -63,6 +63,7 @@ class TestV2CreateAndSearch:
             result = runner.invoke(
                 app,
                 [
+                    "--local",
                     "index",
                     "search",
                     "semantic search embeddings",
@@ -70,7 +71,6 @@ class TestV2CreateAndSearch:
                     "v2-e2e-test",
                     "--engine",
                     "v2",
-                    "--local",
                 ],
             )
         finally:
@@ -88,10 +88,10 @@ class TestV2CreateAndSearch:
                 [
                     "--engine",
                     "v2",
+                    "--local",
                     "index",
                     "search",
                     "document indexing",
-                    "--local",
                 ],
             )
         finally:
@@ -112,12 +112,12 @@ class TestV2CreateAndSearch:
                 [
                     "--engine",
                     "v2",
+                    "--local",
                     "index",
                     "search",
                     "indexing pipeline",
                     "--collection",
                     "v2-e2e-test",
-                    "--local",
                 ],
             )
         finally:
@@ -140,7 +140,7 @@ class TestV2Inspect:
             os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
-                ["index", "inspect", "--engine", "v2", "--local"],
+                ["--local", "index", "inspect", "--engine", "v2"],
             )
         finally:
             os.chdir(original_cwd)
@@ -155,7 +155,7 @@ class TestV2Inspect:
             os.chdir(e2e_workspace)
             result = runner.invoke(
                 app,
-                ["index", "inspect", "v2-e2e-test", "--engine", "v2", "--local"],
+                ["--local", "index", "inspect", "v2-e2e-test", "--engine", "v2"],
             )
         finally:
             os.chdir(original_cwd)
@@ -176,13 +176,13 @@ class TestV2Remove:
             result = runner.invoke(
                 app,
                 [
+                    "--local",
                     "index",
                     "remove",
                     "v2-e2e-test",
                     "--engine",
                     "v2",
                     "--force",
-                    "--local",
                 ],
             )
         finally:

--- a/tests/system/_e2e/test_e2e_v2_mcp.py
+++ b/tests/system/_e2e/test_e2e_v2_mcp.py
@@ -1,0 +1,173 @@
+"""End-to-end test that boots the FastMCP server with engine=v2 and queries it.
+
+Closes the spec done-criterion that "MCP server with [general] engine = v2 in
+config serves v2 collections to AI agents" — exercises the create-via-CLI →
+serve-via-MCP path with the real embedder, FAISS, and LlamaIndex stack.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any, Coroutine, Generator, TypeVar
+
+import pytest
+from fastmcp import Client
+from typer.testing import CliRunner
+
+from indexed.app import app
+from indexed_config import ConfigService
+
+T = TypeVar("T")
+
+runner = CliRunner()
+
+
+@pytest.fixture(scope="module")
+def v2_mcp_workspace(
+    tmp_path_factory: pytest.TempPathFactory, e2e_docs: Path
+) -> Generator[Path, None, None]:
+    """Create a v2 workspace with `[general] engine = "v2"` and seed a collection."""
+    workspace = tmp_path_factory.mktemp("v2_mcp_workspace")
+    indexed_dir = workspace / ".indexed"
+    indexed_dir.mkdir()
+    (indexed_dir / "config.toml").write_text(
+        '[general]\nengine = "v2"\n',
+        encoding="utf-8",
+    )
+
+    original_cwd = os.getcwd()
+    try:
+        os.chdir(workspace)
+        result = runner.invoke(
+            app,
+            [
+                "--engine",
+                "v2",
+                "index",
+                "create",
+                "files",
+                "--collection",
+                "v2-mcp-test",
+                "--path",
+                str(e2e_docs),
+                "--force",
+                "--local",
+            ],
+        )
+        assert result.exit_code == 0, f"Seeding v2 collection failed: {result.stdout}"
+    finally:
+        os.chdir(original_cwd)
+
+    yield workspace
+
+
+@pytest.fixture
+def mcp_v2_chdir(
+    v2_mcp_workspace: Path, monkeypatch: pytest.MonkeyPatch
+) -> Generator[Path, None, None]:
+    """Chdir into the v2 workspace and reset the ConfigService singleton.
+
+    The MCP server's lifespan reads `[general] engine` from the active
+    ConfigService at startup, so a fresh instance bound to the workspace
+    is required for the in-memory client to see engine=v2.
+    """
+    monkeypatch.chdir(v2_mcp_workspace)
+    monkeypatch.setenv("INDEXED__storage__mode", "local")
+    ConfigService.reset()
+    try:
+        yield v2_mcp_workspace
+    finally:
+        ConfigService.reset()
+
+
+def _run(coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+class TestV2MCPServer:
+    """End-to-end MCP server tests with engine=v2."""
+
+    def test_search_tool_returns_v2_results(self, mcp_v2_chdir: Path) -> None:
+        """search tool routes to v2 and returns results from the v2 collection."""
+        from indexed.mcp.server import mcp
+
+        async def go() -> Any:
+            async with Client(mcp) as client:
+                return await client.call_tool(
+                    "search", {"query": "semantic search embeddings"}
+                )
+
+        response = _run(go())
+        payload = _extract_payload(response)
+        assert "error" not in payload, f"search returned error: {payload}"
+        assert payload["query"] == "semantic search embeddings"
+        assert "results" in payload
+
+    def test_search_collection_tool_targets_v2_collection(
+        self, mcp_v2_chdir: Path
+    ) -> None:
+        """search_collection tool reaches the v2 collection by name."""
+        from indexed.mcp.server import mcp
+
+        async def go() -> Any:
+            async with Client(mcp) as client:
+                return await client.call_tool(
+                    "search_collection",
+                    {"collection": "v2-mcp-test", "query": "indexing pipeline"},
+                )
+
+        response = _run(go())
+        payload = _extract_payload(response)
+        assert "error" not in payload, f"search_collection returned error: {payload}"
+        assert payload["query"] == "indexing pipeline"
+
+    def test_collections_resource_lists_v2_collection(self, mcp_v2_chdir: Path) -> None:
+        """resource://collections lists v2 collections present on disk."""
+        from indexed.mcp.server import mcp
+
+        async def go() -> Any:
+            async with Client(mcp) as client:
+                return await client.read_resource("resource://collections")
+
+        result = _run(go())
+        contents = _resource_text(result)
+        parsed = json.loads(contents)
+        assert "v2-mcp-test" in parsed.get("collections", []), (
+            f"v2 collection not in resource payload: {parsed}"
+        )
+
+
+def _extract_payload(response: object) -> dict[str, Any]:
+    """Pull the JSON payload from a FastMCP CallToolResult."""
+    data = getattr(response, "data", None)
+    if isinstance(data, dict):
+        return data
+    structured = getattr(response, "structured_content", None)
+    if isinstance(structured, dict):
+        return structured
+    content = getattr(response, "content", None)
+    if content:
+        text = getattr(content[0], "text", None)
+        if text:
+            parsed: dict[str, Any] = json.loads(text)
+            return parsed
+    raise AssertionError(f"Could not extract payload from response: {response!r}")
+
+
+def _resource_text(result: object) -> str:
+    """Pull the text payload from a FastMCP read_resource result."""
+    if isinstance(result, list) and result:
+        text = getattr(result[0], "text", None)
+        if text:
+            return str(text)
+    contents = getattr(result, "contents", None)
+    if contents:
+        text = getattr(contents[0], "text", None) or getattr(
+            contents[0], "content", None
+        )
+        if text:
+            return str(text)
+    raise AssertionError(f"Could not extract text from resource result: {result!r}")

--- a/tests/system/_e2e/test_e2e_v2_mcp.py
+++ b/tests/system/_e2e/test_e2e_v2_mcp.py
@@ -34,9 +34,14 @@ def v2_mcp_workspace(
     indexed_dir = workspace / ".indexed"
     indexed_dir.mkdir()
     (indexed_dir / "config.toml").write_text(
-        '[general]\nengine = "v2"\n',
+        '[general]\nengine = "v2"\n'
+        '[core.v2.embedding]\nmodel_name = "all-MiniLM-L6-v2"\n'
+        "[core.v2.indexing]\nchunk_size = 512\n"
+        '[core.v2.storage]\nvector_store = "faiss"\n'
+        "[core.v2.search]\nmax_docs = 10\n",
         encoding="utf-8",
     )
+    ConfigService.reset()
 
     original_cwd = os.getcwd()
     try:

--- a/tests/unit/indexed/knowledge/commands/test_create_helpers.py
+++ b/tests/unit/indexed/knowledge/commands/test_create_helpers.py
@@ -497,12 +497,11 @@ class TestBuildV2Connector:
         mock_cls.assert_called_once_with(
             path="/tmp/docs",
             include_patterns=["*"],
-            exclude_patterns=[],
             fail_fast=False,
         )
 
     def test_local_files_forwards_reader_opts(self) -> None:
-        """includePatterns and excludePatterns from reader_opts are forwarded."""
+        """includePatterns and failFast from reader_opts are forwarded."""
         from indexed.knowledge.commands._create_helpers import _build_v2_connector
         from core.v1.engine.services import SourceConfig
 
@@ -513,7 +512,6 @@ class TestBuildV2Connector:
             indexer="default",
             reader_opts={
                 "includePatterns": ["*.md", "*.txt"],
-                "excludePatterns": ["*.tmp"],
                 "failFast": True,
             },
         )
@@ -524,7 +522,6 @@ class TestBuildV2Connector:
 
         call_kwargs = mock_cls.call_args.kwargs
         assert call_kwargs["include_patterns"] == ["*.md", "*.txt"]
-        assert call_kwargs["exclude_patterns"] == ["*.tmp"]
         assert call_kwargs["fail_fast"] is True
 
     def test_remote_connector_uses_from_config(self) -> None:

--- a/tests/unit/indexed/knowledge/commands/test_inspect.py
+++ b/tests/unit/indexed/knowledge/commands/test_inspect.py
@@ -282,3 +282,134 @@ class TestInspectCollectionsCommandV2:
 
         assert result.exit_code == 1
         assert "missing" in result.stdout
+
+
+def _write_v2_manifest(root: Path, name: str, *, docs: int, chunks: int) -> None:
+    import json as _json
+
+    coll = root / name
+    coll.mkdir(parents=True, exist_ok=True)
+    (coll / "manifest.json").write_text(
+        _json.dumps(
+            {
+                "name": name,
+                "version": "2.0",
+                "source_type": "localFiles",
+                "num_documents": docs,
+                "num_chunks": chunks,
+                "embed_model_name": "all-MiniLM-L6-v2",
+                "vector_store_type": "faiss",
+                "created_time": "2025-01-01T00:00:00Z",
+                "updated_time": "2025-01-02T00:00:00Z",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_v1_manifest(root: Path, name: str, *, docs: int, chunks: int) -> None:
+    import json as _json
+
+    coll = root / name
+    coll.mkdir(parents=True, exist_ok=True)
+    (coll / "manifest.json").write_text(
+        _json.dumps(
+            {
+                "collectionName": name,
+                "numberOfDocuments": docs,
+                "numberOfChunks": chunks,
+                "indexers": [{"name": "FAISS"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+class TestInspectAutoDetect:
+    """Per-collection auto-routing fixes the v2 silent-zeros bug."""
+
+    def test_v2_detail_view_reports_real_counts_without_engine_flag(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """`inspect <v2-coll>` must return the v2 manifest's document/chunk counts."""
+        from unittest.mock import MagicMock
+
+        _write_v2_manifest(tmp_path, "indexed", docs=42, chunks=137)
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        v2_info = MagicMock()
+        v2_info.name = "indexed"
+        v2_info.source_type = "localFiles"
+        v2_info.relative_path = None
+        v2_info.number_of_documents = 42
+        v2_info.number_of_chunks = 137
+        v2_info.disk_size_bytes = 1024
+        v2_info.index_size_bytes = 0
+        v2_info.created_time = "2025-01-01T00:00:00Z"
+        v2_info.updated_time = "2025-01-02T00:00:00Z"
+
+        with patch("core.v2.services.inspect", return_value=v2_info) as v2_inspect:
+            result = runner.invoke(inspect_cmd.app, ["indexed"])
+
+        assert result.exit_code == 0, result.output
+        v2_inspect.assert_called_once()
+        assert "42" in result.stdout
+        assert "137" in result.stdout
+
+    def test_mixed_engine_list_view_renders_per_row(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """A mixed-engine repo lists v1 + v2 with their own counts."""
+        from unittest.mock import MagicMock
+
+        _write_v1_manifest(tmp_path, "v1coll", docs=3, chunks=9)
+        _write_v2_manifest(tmp_path, "v2coll", docs=5, chunks=11)
+
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        v1_info = _make_collection("v1coll", docs=3, chunks=9)
+        monkeypatch.setattr(inspect_cmd, "inspect", lambda *a, **kw: [v1_info])
+
+        v2_info = MagicMock()
+        v2_info.name = "v2coll"
+        v2_info.source_type = "localFiles"
+        v2_info.relative_path = None
+        v2_info.number_of_documents = 5
+        v2_info.number_of_chunks = 11
+        v2_info.disk_size_bytes = 2048
+        v2_info.index_size_bytes = 0
+        v2_info.created_time = "2025-01-01T00:00:00Z"
+        v2_info.updated_time = "2025-01-02T00:00:00Z"
+
+        with patch("core.v2.services.inspect", return_value=v2_info):
+            result = runner.invoke(inspect_cmd.app, [])
+
+        assert result.exit_code == 0, result.output
+        # Both rows shown
+        assert "v1coll" in result.stdout
+        assert "v2coll" in result.stdout
+        # Real counts for each
+        assert "3" in result.stdout and "9" in result.stdout
+        assert "5" in result.stdout and "11" in result.stdout
+
+    def test_force_v1_engine_in_list_view_skips_per_row(
+        self, monkeypatch, tmp_path
+    ) -> None:
+        """`--engine v1` reverts to single-engine list (escape hatch)."""
+        _write_v2_manifest(tmp_path, "v2coll", docs=99, chunks=99)
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        sentinel = _make_collection("v2coll", docs=0, chunks=0)
+        monkeypatch.setattr(inspect_cmd, "inspect", lambda *a, **kw: [sentinel])
+
+        with patch("core.v2.services.inspect") as v2_inspect:
+            result = runner.invoke(inspect_cmd.app, ["--engine", "v1"])
+
+        assert result.exit_code == 0
+        v2_inspect.assert_not_called()

--- a/tests/unit/indexed/knowledge/commands/test_remove.py
+++ b/tests/unit/indexed/knowledge/commands/test_remove.py
@@ -276,3 +276,77 @@ class TestRemoveCommandV2:
         parsed = json.loads(result.stdout)
         assert parsed["status"] == "removed"
         assert parsed["collection"] == "docs"
+
+
+class TestRemoveAutoDetect:
+    """Per-collection engine auto-detection in `remove`."""
+
+    def test_v2_manifest_routes_to_v2_clear_without_flag(
+        self, monkeypatch: "Any", tmp_path
+    ) -> None:
+        """A v2 manifest on disk routes to v2 clear without --engine v2."""
+        import json as _json
+        from unittest.mock import patch, MagicMock
+        from indexed.utils import storage_info as storage_info_mod
+
+        coll_dir = tmp_path / "docs"
+        coll_dir.mkdir()
+        (coll_dir / "manifest.json").write_text(
+            _json.dumps({"name": "docs", "version": "2.0"}), encoding="utf-8"
+        )
+
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        v2_clear_calls: list = []
+
+        def fake_v2_clear(names, **kwargs):
+            v2_clear_calls.extend(names)
+
+        mock_coll = _make_collection("docs")
+
+        set_simple_output(True)
+        try:
+            with patch("core.v2.services.status", return_value=[mock_coll]):
+                with patch("core.v2.services.clear", side_effect=fake_v2_clear):
+                    monkeypatch.setattr(remove_cmd, "Index", lambda: MagicMock())
+                    result = runner.invoke(remove_cmd.app, ["docs"])
+        finally:
+            reset_simple_output()
+
+        assert result.exit_code == 0, result.output
+        assert v2_clear_calls == ["docs"]
+
+    def test_force_v1_overrides_v2_manifest(
+        self, monkeypatch: "Any", tmp_path
+    ) -> None:
+        """--engine v1 forces v1 path even with v2 manifest on disk."""
+        import json as _json
+        from unittest.mock import MagicMock
+        from indexed.utils import storage_info as storage_info_mod
+
+        coll_dir = tmp_path / "docs"
+        coll_dir.mkdir()
+        (coll_dir / "manifest.json").write_text(
+            _json.dumps({"name": "docs", "version": "2.0"}), encoding="utf-8"
+        )
+
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        mock_coll = _make_collection("docs")
+        mock_index = MagicMock()
+        mock_index.remove.return_value = None
+
+        set_simple_output(True)
+        try:
+            monkeypatch.setattr(remove_cmd, "Index", lambda: mock_index)
+            monkeypatch.setattr(remove_cmd, "inspect", lambda: [mock_coll])
+            result = runner.invoke(remove_cmd.app, ["docs", "--engine", "v1"])
+        finally:
+            reset_simple_output()
+
+        assert result.exit_code == 0
+        mock_index.remove.assert_called_once_with("docs")

--- a/tests/unit/indexed/knowledge/commands/test_remove.py
+++ b/tests/unit/indexed/knowledge/commands/test_remove.py
@@ -318,9 +318,7 @@ class TestRemoveAutoDetect:
         assert result.exit_code == 0, result.output
         assert v2_clear_calls == ["docs"]
 
-    def test_force_v1_overrides_v2_manifest(
-        self, monkeypatch: "Any", tmp_path
-    ) -> None:
+    def test_force_v1_overrides_v2_manifest(self, monkeypatch: "Any", tmp_path) -> None:
         """--engine v1 forces v1 path even with v2 manifest on disk."""
         import json as _json
         from unittest.mock import MagicMock

--- a/tests/unit/indexed/knowledge/commands/test_search.py
+++ b/tests/unit/indexed/knowledge/commands/test_search.py
@@ -805,14 +805,10 @@ class TestSearchAutoDetect:
 
         with patch("indexed_config.ConfigService") as mock_cfg:
             mock_cfg.instance.return_value.bind.return_value = mock_provider
-            with patch(
-                "core.v2.services.status", return_value=[mock_v2_status_obj]
-            ):
+            with patch("core.v2.services.status", return_value=[mock_v2_status_obj]):
                 set_simple_output(True)
                 try:
-                    result = runner.invoke(
-                        search_cmd.app, ["query", "-c", "indexed"]
-                    )
+                    result = runner.invoke(search_cmd.app, ["query", "-c", "indexed"])
                 finally:
                     reset_simple_output()
 

--- a/tests/unit/indexed/knowledge/commands/test_search.py
+++ b/tests/unit/indexed/knowledge/commands/test_search.py
@@ -742,3 +742,152 @@ class TestSearchCommandV2:
         from core.v2.services import search as v2_search_fn
 
         assert search_cmd.svc_search_v2 is v2_search_fn
+
+
+class TestSearchAutoDetect:
+    """Tests for per-collection engine auto-detection in `search`."""
+
+    def _write_v2_manifest(self, root: Path, name: str) -> None:
+        import json as _json
+
+        coll = root / name
+        coll.mkdir(parents=True, exist_ok=True)
+        (coll / "manifest.json").write_text(
+            _json.dumps({"name": name, "version": "2.0"}), encoding="utf-8"
+        )
+
+    def _write_v1_manifest(self, root: Path, name: str) -> None:
+        import json as _json
+
+        coll = root / name
+        coll.mkdir(parents=True, exist_ok=True)
+        (coll / "manifest.json").write_text(
+            _json.dumps(
+                {
+                    "collectionName": name,
+                    "indexers": [{"name": "FAISS"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+
+    def test_v2_collection_routes_to_v2_without_flag(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """A v2 manifest on disk routes to v2 search even with config default v1."""
+        from unittest.mock import MagicMock
+        from core.v2.config import CoreV2SearchConfig, CoreV2EmbeddingConfig
+        from indexed.utils.simple_output import set_simple_output, reset_simple_output
+
+        self._write_v2_manifest(tmp_path, "indexed")
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.get.side_effect = lambda cls: (
+            CoreV2SearchConfig()
+            if cls == CoreV2SearchConfig
+            else CoreV2EmbeddingConfig()
+        )
+        mock_v2_status_obj = MagicMock()
+        mock_v2_status_obj.name = "indexed"
+
+        v2_calls: List[Dict[str, Any]] = []
+
+        def fake_v2_search(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+            v2_calls.append(kwargs)
+            return {"collectionName": "indexed", "results": []}
+
+        monkeypatch.setattr(search_cmd, "Index", lambda: None)
+        monkeypatch.setattr(search_cmd, "setup_root_logger", lambda **kw: None)
+        monkeypatch.setattr(search_cmd, "svc_search_v2", fake_v2_search)
+
+        with patch("indexed_config.ConfigService") as mock_cfg:
+            mock_cfg.instance.return_value.bind.return_value = mock_provider
+            with patch(
+                "core.v2.services.status", return_value=[mock_v2_status_obj]
+            ):
+                set_simple_output(True)
+                try:
+                    result = runner.invoke(
+                        search_cmd.app, ["query", "-c", "indexed"]
+                    )
+                finally:
+                    reset_simple_output()
+
+        assert result.exit_code == 0, result.output
+        assert len(v2_calls) == 1
+
+    def test_force_v1_flag_overrides_v2_manifest(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """--engine v1 against a v2 layout falls into v1 path; empty indexers
+        triggers the new defensive print_error rather than IndexError."""
+        from indexed.utils.simple_output import set_simple_output, reset_simple_output
+
+        self._write_v2_manifest(tmp_path, "indexed")
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        # v1 status returns empty indexers for the v2 layout
+        empty_status = MagicMockStatus(name="indexed", indexers=[])
+
+        def fake_v1_status(names=None, collections_path=None, **kwargs):
+            if names is None:
+                return [empty_status]
+            return [empty_status]
+
+        monkeypatch.setattr(search_cmd, "Index", lambda: None)
+        monkeypatch.setattr(search_cmd, "setup_root_logger", lambda **kw: None)
+        monkeypatch.setattr(search_cmd, "status", fake_v1_status)
+
+        set_simple_output(True)
+        try:
+            result = runner.invoke(
+                search_cmd.app, ["query", "-c", "indexed", "--engine", "v1"]
+            )
+        finally:
+            reset_simple_output()
+
+        # Defensive guard hit; not an IndexError
+        assert result.exit_code == 1
+        assert "IndexError" not in (result.output or "")
+
+    def test_no_collection_arg_uses_config_default(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """When -c is omitted, manifest detection is skipped (config default applies)."""
+        from indexed.utils.simple_output import set_simple_output, reset_simple_output
+
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
+
+        def fake_v1_status(names=None, collections_path=None, **kwargs):
+            return []
+
+        monkeypatch.setattr(search_cmd, "Index", lambda: None)
+        monkeypatch.setattr(search_cmd, "setup_root_logger", lambda **kw: None)
+        monkeypatch.setattr(search_cmd, "status", fake_v1_status)
+
+        set_simple_output(True)
+        try:
+            result = runner.invoke(search_cmd.app, ["query"])
+        finally:
+            reset_simple_output()
+
+        # No collections + simple output → JSON error message, exit 0
+        assert result.exit_code == 0
+        assert "No collections found" in (result.stdout or "")
+
+
+class MagicMockStatus:
+    """Lightweight stand-in for v1 CollectionStatus with controllable indexers."""
+
+    def __init__(self, name: str, indexers: list) -> None:
+        self.name = name
+        self.indexers = indexers
+        self.number_of_documents = 0
+        self.number_of_chunks = 0

--- a/tests/unit/indexed/knowledge/commands/test_update.py
+++ b/tests/unit/indexed/knowledge/commands/test_update.py
@@ -884,6 +884,7 @@ class TestUpdateAutoDetect:
 
     def _write_v2(self, root, name):
         import json as _json
+
         coll = root / name
         coll.mkdir(parents=True, exist_ok=True)
         (coll / "manifest.json").write_text(
@@ -908,6 +909,7 @@ class TestUpdateAutoDetect:
         tmp_path,
     ):
         from indexed.utils import storage_info as storage_info_mod
+
         mock_verbose.return_value = False
         cfg = Mock()
         cfg.resolve_storage_mode.return_value = "global"
@@ -915,7 +917,9 @@ class TestUpdateAutoDetect:
         cfg.store.global_path = "/tmp/c.toml"
         mock_cfg.instance.return_value = cfg
         self._write_v2(tmp_path, "v2coll")
-        monkeypatch.setattr(storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path)
+        monkeypatch.setattr(
+            storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path
+        )
         v1_status = Mock()
         v1_status.name = "v2coll"
         v1_status.source_type = "localFiles"
@@ -930,6 +934,7 @@ class TestUpdateAutoDetect:
         before_info.source_type = "localFiles"
         mock_inspect.return_value = [before_info]
         from indexed.app import app
+
         result = runner.invoke(app, ["index", "update", "v2coll", "--engine", "v1"])
         assert result.exit_code == 1
         assert "indexer metadata" in result.output

--- a/tests/unit/indexed/knowledge/commands/test_update.py
+++ b/tests/unit/indexed/knowledge/commands/test_update.py
@@ -877,3 +877,59 @@ class TestUpdateCommand:
         assert result.exit_code == 0
         # For a single collection, result summary is not shown (create_summary not called)
         mock_create_summary.assert_not_called()
+
+
+class TestUpdateAutoDetect:
+    """Per-collection engine auto-detection in `update`."""
+
+    def _write_v2(self, root, name):
+        import json as _json
+        coll = root / name
+        coll.mkdir(parents=True, exist_ok=True)
+        (coll / "manifest.json").write_text(
+            _json.dumps({"name": name, "version": "2.0"}), encoding="utf-8"
+        )
+
+    @patch("indexed.knowledge.commands.update.setup_root_logger")
+    @patch("indexed.knowledge.commands.update.ConfigService")
+    @patch("indexed.knowledge.commands.update.is_verbose_mode")
+    @patch("indexed.knowledge.commands.update.svc_status")
+    @patch("indexed.knowledge.commands.update.inspect")
+    @patch("indexed.knowledge.commands.update.ensure_credentials_for_source")
+    def test_force_v1_against_v2_layout_emits_hard_error(
+        self,
+        mock_ensure_creds,
+        mock_inspect,
+        mock_svc_status,
+        mock_verbose,
+        mock_cfg,
+        mock_logger,
+        monkeypatch,
+        tmp_path,
+    ):
+        from indexed.utils import storage_info as storage_info_mod
+        mock_verbose.return_value = False
+        cfg = Mock()
+        cfg.resolve_storage_mode.return_value = "global"
+        cfg.store.has_global_config.return_value = True
+        cfg.store.global_path = "/tmp/c.toml"
+        mock_cfg.instance.return_value = cfg
+        self._write_v2(tmp_path, "v2coll")
+        monkeypatch.setattr(storage_info_mod, "resolve_preferred_collections_path", lambda: tmp_path)
+        v1_status = Mock()
+        v1_status.name = "v2coll"
+        v1_status.source_type = "localFiles"
+        v1_status.indexers = []
+        mock_svc_status.return_value = [v1_status]
+        before_info = Mock()
+        before_info.name = "v2coll"
+        before_info.number_of_documents = 0
+        before_info.number_of_chunks = 0
+        before_info.disk_size_bytes = 0
+        before_info.updated_time = None
+        before_info.source_type = "localFiles"
+        mock_inspect.return_value = [before_info]
+        from indexed.app import app
+        result = runner.invoke(app, ["index", "update", "v2coll", "--engine", "v1"])
+        assert result.exit_code == 1
+        assert "indexer metadata" in result.output

--- a/tests/unit/indexed/mcp/test_cli.py
+++ b/tests/unit/indexed/mcp/test_cli.py
@@ -76,7 +76,6 @@ class TestRunImpl:
             host="0.0.0.0",
             port=9000,
             log_level="INFO",
-            json_logs=False,
         )
 
     @patch("indexed.mcp.server.mcp")

--- a/tests/unit/indexed/mcp/test_tools.py
+++ b/tests/unit/indexed/mcp/test_tools.py
@@ -57,3 +57,68 @@ class TestNormalizeV2Results:
         raw = {"collectionName": "docs", "results": [chunk]}
         out = _normalize_v2_results(raw)
         assert out["docs"]["results"][0] is chunk
+
+
+class TestResolveEngineForCollection:
+    """Per-collection engine resolution helper used by tools and resources."""
+
+    def _write_manifest(self, root, name: str, payload: dict) -> None:
+        import json
+        from pathlib import Path
+
+        coll = Path(root) / name
+        coll.mkdir(parents=True, exist_ok=True)
+        (coll / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_v2_manifest_returns_v2(self, monkeypatch, tmp_path) -> None:
+        from indexed.mcp.config import resolve_engine_for_collection
+        from indexed.utils import storage_info as storage_info_mod
+
+        self._write_manifest(tmp_path, "docs", {"name": "docs", "version": "2.0"})
+        monkeypatch.setattr(
+            storage_info_mod,
+            "resolve_preferred_collections_path",
+            lambda: tmp_path,
+        )
+
+        assert resolve_engine_for_collection("docs", None, lambda: "v1") == "v2"
+
+    def test_v1_manifest_returns_v1(self, monkeypatch, tmp_path) -> None:
+        from indexed.mcp.config import resolve_engine_for_collection
+        from indexed.utils import storage_info as storage_info_mod
+
+        self._write_manifest(
+            tmp_path, "docs", {"collectionName": "docs", "indexers": []}
+        )
+        monkeypatch.setattr(
+            storage_info_mod,
+            "resolve_preferred_collections_path",
+            lambda: tmp_path,
+        )
+
+        # Loader returns v2 — but manifest says v1, manifest wins.
+        assert resolve_engine_for_collection("docs", None, lambda: "v2") == "v1"
+
+    def test_missing_manifest_falls_back_to_loader(self, monkeypatch, tmp_path) -> None:
+        from indexed.mcp.config import resolve_engine_for_collection
+        from indexed.utils import storage_info as storage_info_mod
+
+        monkeypatch.setattr(
+            storage_info_mod,
+            "resolve_preferred_collections_path",
+            lambda: tmp_path,
+        )
+
+        assert resolve_engine_for_collection("ghost", None, lambda: "v2") == "v2"
+
+    def test_empty_collection_name_uses_loader(self, monkeypatch, tmp_path) -> None:
+        from indexed.mcp.config import resolve_engine_for_collection
+        from indexed.utils import storage_info as storage_info_mod
+
+        monkeypatch.setattr(
+            storage_info_mod,
+            "resolve_preferred_collections_path",
+            lambda: tmp_path,
+        )
+
+        assert resolve_engine_for_collection("", None, lambda: "v2") == "v2"

--- a/tests/unit/indexed/test_app.py
+++ b/tests/unit/indexed/test_app.py
@@ -203,6 +203,37 @@ class TestMigrateCommand:
         assert call_kwargs.get("dry_run") is True
 
 
+class TestEngineValidation:
+    """Validate the global --engine option at the CLI boundary."""
+
+    def test_invalid_engine_exits_nonzero(self) -> None:
+        result = runner.invoke(app, ["--engine", "vv2", "index", "inspect"])
+        assert result.exit_code != 0
+        combined = (result.output or "") + (result.stderr or "")
+        assert "Engine must be" in combined
+
+    def test_engine_v2_normalizes_uppercase(self) -> None:
+        ctx = Mock()
+        ctx.invoked_subcommand = "search"
+        ctx.resilient_parsing = False
+        captured: dict = {}
+        ctx.ensure_object = Mock()
+        ctx.obj = captured
+
+        with patch("indexed.app.bootstrap_logging"):
+            _init_app(
+                ctx,
+                local=False,
+                verbose=False,
+                log_level=None,
+                json_logs=False,
+                simple_output=False,
+                engine="V2",
+            )
+
+        assert captured["engine"] == "v2"
+
+
 class TestMainFunction:
     """Test main entry point function."""
 

--- a/tests/unit/indexed/test_engine_router.py
+++ b/tests/unit/indexed/test_engine_router.py
@@ -40,6 +40,22 @@ class TestGetEffectiveEngine:
     def test_command_flag_lowercases(self) -> None:
         assert get_effective_engine("V2") == "v2"
 
+    def test_invalid_command_engine_falls_through(self) -> None:
+        """Typos in command engine fall through instead of being returned verbatim."""
+        with patch("click.get_current_context", side_effect=RuntimeError("no ctx")):
+            with patch("indexed_config.ConfigService") as mock_svc_cls:
+                mock_svc_cls.instance.side_effect = Exception("no config")
+                assert get_effective_engine("vv2") == "v1"
+
+    def test_invalid_ctx_engine_falls_through(self) -> None:
+        """Corrupt ctx engine falls through to config branch."""
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {"engine": "vv2"}
+        with patch("click.get_current_context", return_value=mock_ctx):
+            with patch("indexed_config.ConfigService") as mock_svc_cls:
+                mock_svc_cls.instance.side_effect = Exception("no config")
+                assert get_effective_engine(None) == "v1"
+
     def test_root_flag_from_ctx_obj(self) -> None:
         """Root callback engine stored in ctx.obj is second priority."""
         mock_ctx = MagicMock()

--- a/tests/unit/indexed/test_engine_router.py
+++ b/tests/unit/indexed/test_engine_router.py
@@ -1,11 +1,14 @@
 """Unit tests for the engine router."""
 
+import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from indexed.services.engine_router import (
     GeneralConfig,
+    detect_collection_engine,
     get_collection_service,
     get_effective_engine,
     get_inspect_service,
@@ -94,6 +97,132 @@ class TestGetEffectiveEngine:
             with patch("indexed_config.ConfigService") as mock_svc_cls:
                 mock_svc_cls.instance.side_effect = Exception("no config")
                 result = get_effective_engine(opaque)  # type: ignore[arg-type]
+        assert result == "v1"
+
+
+class TestDetectCollectionEngine:
+    def _write_manifest(self, root: Path, name: str, payload) -> None:
+        coll = root / name
+        coll.mkdir(parents=True, exist_ok=True)
+        (coll / "manifest.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_detects_v2_from_version_2(self, tmp_path: Path) -> None:
+        self._write_manifest(
+            tmp_path, "v2coll", {"name": "v2coll", "version": "2.0", "num_documents": 1}
+        )
+        assert detect_collection_engine("v2coll", tmp_path) == "v2"
+
+    def test_detects_v1_when_no_version_key(self, tmp_path: Path) -> None:
+        self._write_manifest(
+            tmp_path,
+            "v1coll",
+            {
+                "collectionName": "v1coll",
+                "numberOfDocuments": 4,
+                "numberOfChunks": 12,
+                "indexers": [{"name": "FAISS"}],
+            },
+        )
+        assert detect_collection_engine("v1coll", tmp_path) == "v1"
+
+    def test_returns_none_for_missing_collection_dir(self, tmp_path: Path) -> None:
+        assert detect_collection_engine("ghost", tmp_path) is None
+
+    def test_returns_none_when_manifest_missing(self, tmp_path: Path) -> None:
+        (tmp_path / "halfwritten").mkdir()
+        assert detect_collection_engine("halfwritten", tmp_path) is None
+
+    def test_returns_none_for_malformed_json(self, tmp_path: Path) -> None:
+        coll = tmp_path / "broken"
+        coll.mkdir()
+        (coll / "manifest.json").write_text("{not json", encoding="utf-8")
+        assert detect_collection_engine("broken", tmp_path) is None
+
+    def test_returns_none_for_non_dict_payload(self, tmp_path: Path) -> None:
+        self._write_manifest(tmp_path, "listy", ["not", "a", "dict"])
+        assert detect_collection_engine("listy", tmp_path) is None
+
+    def test_version_1_string_returns_v1(self, tmp_path: Path) -> None:
+        # Forward-proof: explicit "1.x" still maps to v1.
+        self._write_manifest(tmp_path, "v1explicit", {"version": "1.0"})
+        assert detect_collection_engine("v1explicit", tmp_path) == "v1"
+
+    def test_accepts_string_path(self, tmp_path: Path) -> None:
+        self._write_manifest(tmp_path, "v2coll", {"version": "2.0"})
+        assert detect_collection_engine("v2coll", str(tmp_path)) == "v2"
+
+
+class TestGetEffectiveEngineWithDetection:
+    def _write_v2(self, root: Path, name: str) -> None:
+        coll = root / name
+        coll.mkdir(parents=True, exist_ok=True)
+        (coll / "manifest.json").write_text(
+            json.dumps({"name": name, "version": "2.0"}), encoding="utf-8"
+        )
+
+    def _write_v1(self, root: Path, name: str) -> None:
+        coll = root / name
+        coll.mkdir(parents=True, exist_ok=True)
+        (coll / "manifest.json").write_text(
+            json.dumps({"collectionName": name, "indexers": []}), encoding="utf-8"
+        )
+
+    def test_command_flag_overrides_v2_manifest(self, tmp_path: Path) -> None:
+        self._write_v2(tmp_path, "coll")
+        with patch("click.get_current_context", side_effect=RuntimeError("no ctx")):
+            result = get_effective_engine(
+                "v1", collection="coll", collections_path=tmp_path
+            )
+        assert result == "v1"
+
+    def test_v2_manifest_returns_v2_without_flag(self, tmp_path: Path) -> None:
+        self._write_v2(tmp_path, "coll")
+        with patch("click.get_current_context", side_effect=RuntimeError("no ctx")):
+            with patch("indexed_config.ConfigService") as mock_svc_cls:
+                mock_svc_cls.instance.side_effect = Exception("ignored")
+                result = get_effective_engine(
+                    None, collection="coll", collections_path=tmp_path
+                )
+        assert result == "v2"
+
+    def test_v1_manifest_returns_v1_without_flag(self, tmp_path: Path) -> None:
+        self._write_v1(tmp_path, "coll")
+        with patch("click.get_current_context", side_effect=RuntimeError("no ctx")):
+            with patch("indexed_config.ConfigService") as mock_svc_cls:
+                mock_svc_cls.instance.side_effect = Exception("ignored")
+                result = get_effective_engine(
+                    None, collection="coll", collections_path=tmp_path
+                )
+        assert result == "v1"
+
+    def test_missing_manifest_falls_back_to_config_default(self, tmp_path: Path) -> None:
+        with patch("click.get_current_context", side_effect=RuntimeError("no ctx")):
+            mock_svc = MagicMock()
+            mock_provider = MagicMock()
+            mock_svc.bind.return_value = mock_provider
+            mock_provider.get.return_value = GeneralConfig(engine="v2")
+            with patch("indexed_config.ConfigService") as mock_svc_cls:
+                mock_svc_cls.instance.return_value = mock_svc
+                result = get_effective_engine(
+                    None, collection="ghost", collections_path=tmp_path
+                )
+        assert result == "v2"
+
+    def test_no_collection_arg_preserves_legacy_behavior(self, tmp_path: Path) -> None:
+        with patch("click.get_current_context", side_effect=RuntimeError("no ctx")):
+            with patch("indexed_config.ConfigService") as mock_svc_cls:
+                mock_svc_cls.instance.side_effect = Exception("no config")
+                # No collection / no path → legacy path → "v1"
+                assert get_effective_engine(None) == "v1"
+
+    def test_ctx_obj_engine_takes_priority_over_manifest(self, tmp_path: Path) -> None:
+        self._write_v2(tmp_path, "coll")
+        mock_ctx = MagicMock()
+        mock_ctx.obj = {"engine": "v1"}
+        with patch("click.get_current_context", return_value=mock_ctx):
+            result = get_effective_engine(
+                None, collection="coll", collections_path=tmp_path
+            )
         assert result == "v1"
 
 

--- a/tests/unit/indexed/test_engine_router.py
+++ b/tests/unit/indexed/test_engine_router.py
@@ -195,7 +195,9 @@ class TestGetEffectiveEngineWithDetection:
                 )
         assert result == "v1"
 
-    def test_missing_manifest_falls_back_to_config_default(self, tmp_path: Path) -> None:
+    def test_missing_manifest_falls_back_to_config_default(
+        self, tmp_path: Path
+    ) -> None:
         with patch("click.get_current_context", side_effect=RuntimeError("no ctx")):
             mock_svc = MagicMock()
             mock_provider = MagicMock()

--- a/tests/unit/indexed_core/v2/test_embedding.py
+++ b/tests/unit/indexed_core/v2/test_embedding.py
@@ -78,6 +78,22 @@ class TestGetEmbedModel:
             assert model1 is not model2
             assert mock_cls.call_count == 2
 
+    def test_short_and_full_repo_id_share_cache(self) -> None:
+        """Bare name and prefixed repo id collapse onto the same cache entry."""
+        mock_cls = MagicMock()
+        with patch.dict(
+            "sys.modules",
+            {
+                "llama_index.embeddings.huggingface": MagicMock(
+                    HuggingFaceEmbedding=mock_cls
+                )
+            },
+        ):
+            short = get_embed_model("all-MiniLM-L6-v2")
+            full = get_embed_model("sentence-transformers/all-MiniLM-L6-v2")
+            assert short is full
+            assert mock_cls.call_count == 1
+
     def test_raises_embedding_error_on_import_failure(self) -> None:
         with patch.dict("sys.modules", {"llama_index.embeddings.huggingface": None}):
             with pytest.raises(

--- a/tests/unit/indexed_core/v2/test_index.py
+++ b/tests/unit/indexed_core/v2/test_index.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from core.v2 import Index, IndexConfig
 
@@ -63,6 +64,13 @@ class TestIndex:
 
         index.update("docs")
         mock_create.assert_called_once()
+
+    def test_update_unknown_collection_raises(self) -> None:
+        from core.v2.errors import CollectionNotFoundError
+
+        index = Index()
+        with pytest.raises(CollectionNotFoundError, match="ghost"):
+            index.update("ghost")
 
     @patch("core.v2.storage.read_manifest")
     def test_status_single(self, mock_read: MagicMock) -> None:

--- a/tests/unit/indexed_core/v2/test_lazy_imports.py
+++ b/tests/unit/indexed_core/v2/test_lazy_imports.py
@@ -1,0 +1,39 @@
+"""Verify v2 packages remain side-effect-free at import time."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def _run(snippet: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-c", snippet],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def test_core_v2_import_does_not_load_llama_index() -> None:
+    snippet = (
+        "import sys; import core.v2; "
+        "print('OK' if 'llama_index.core' not in sys.modules else 'LEAKED')"
+    )
+    assert _run(snippet) == "OK"
+
+
+def test_core_v2_services_import_does_not_load_llama_index() -> None:
+    snippet = (
+        "import sys; import core.v2.services; "
+        "print('OK' if 'llama_index.core' not in sys.modules else 'LEAKED')"
+    )
+    assert _run(snippet) == "OK"
+
+
+def test_index_attribute_resolves_lazily() -> None:
+    from core.v2 import Index, IndexConfig
+
+    assert Index is not None
+    assert IndexConfig is not None

--- a/tests/unit/indexed_core/v2/test_storage.py
+++ b/tests/unit/indexed_core/v2/test_storage.py
@@ -27,6 +27,30 @@ class TestGetCollectionPath:
         assert p1 != p2
 
 
+class TestCollectionNameValidation:
+    """get_collection_path rejects names that could escape the root."""
+
+    def test_rejects_dotdot(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match=r"\.\.|outside"):
+            get_collection_path("../etc", collections_dir=tmp_path)
+
+    def test_rejects_absolute(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="absolute"):
+            get_collection_path("/etc/passwd", collections_dir=tmp_path)
+
+    def test_rejects_multi_segment(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="single path segment"):
+            get_collection_path("a/b", collections_dir=tmp_path)
+
+    def test_rejects_empty(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            get_collection_path("", collections_dir=tmp_path)
+
+    def test_rejects_whitespace(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="empty"):
+            get_collection_path("   ", collections_dir=tmp_path)
+
+
 class TestWriteManifest:
     """write_manifest creates a manifest.json file."""
 


### PR DESCRIPTION
https://claude.ai/code/session_01UA4wPogRKfNBMZEVXT5SGa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global --engine option for CLI commands to select v1 or v2 (defaults to v1).
  * v2 engine available (LlamaIndex-based) as an alternative indexing/search implementation.

* **Improvements**
  * CI now caches the default embedding model for faster tests.
  * .gitignore updated to exclude coverage.json.
  * MCP server defaults to non-JSON logs for non-stdio transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->