### PR TITLE
ci: add version sync script for release automation

### DIFF
--- a/.github/workflows/python-release-ci.yml
+++ b/.github/workflows/python-release-ci.yml
@@ -38,6 +38,9 @@ jobs:
     - name: Install dependencies
       run: uv sync
 
+    - name: Sync version with release tag
+      run: uv run python tools/sync_version.py ${{ github.ref_name }}
+
     - name: Build distributable wheel
       run: uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
 
@@ -79,7 +82,7 @@ jobs:
       # Default packages-dir: dist/ — no override needed.
 
     - name: Attach wheel to GitHub Release
-      if: github.event_name == 'release'
+      if: always() && github.event_name == 'release'
       uses: softprops/action-gh-release@v2
       with:
         files: dist/*

--- a/.github/workflows/python-release-ci.yml
+++ b/.github/workflows/python-release-ci.yml
@@ -39,7 +39,9 @@ jobs:
       run: uv sync
 
     - name: Sync version with release tag
-      run: uv run python tools/sync_version.py ${{ github.ref_name }}
+      env:
+        REF_NAME: ${{ github.ref_name }}
+      run: uv run python tools/sync_version.py "$REF_NAME"
 
     - name: Build distributable wheel
       run: uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -14,7 +14,7 @@ from pathlib import Path
 
 PYPROJECT = Path("apps/indexed/pyproject.toml")
 VERSION_RE = re.compile(r'^(version\s*=\s*")[^"]*(")', re.MULTILINE)
-SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
 
 
 def main() -> None:

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# Sync apps/indexed/pyproject.toml version with a release tag.
+#
+# Usage:
+#   uv run python tools/sync_version.py <tag>
+#
+# The tag may include or omit the 'v' prefix (e.g. 'v0.1.0' or '0.1.0').
+# If the tag is not a valid semver string the script exits successfully with
+# a warning so that workflow_dispatch runs on branch refs are not blocked.
+
+import re
+import sys
+from pathlib import Path
+
+PYPROJECT = Path("apps/indexed/pyproject.toml")
+VERSION_RE = re.compile(r'^(version\s*=\s*")[^"]*(")', re.MULTILINE)
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: sync_version.py <tag>", file=sys.stderr)
+        sys.exit(1)
+
+    raw_tag = sys.argv[1]
+    version = raw_tag.lstrip("v")
+
+    if not SEMVER_RE.match(version):
+        print(f"[sync_version] '{raw_tag}' is not a semver tag — skipping.")
+        return
+
+    content = PYPROJECT.read_text(encoding="utf-8")
+    match = VERSION_RE.search(content)
+    if not match:
+        print(f"[sync_version] Could not find version field in {PYPROJECT}", file=sys.stderr)
+        sys.exit(1)
+
+    current = match.group(0).split('"')[1]
+    if current == version:
+        print(f"[sync_version] Version already {version} — no change needed.")
+        return
+
+    updated = VERSION_RE.sub(rf"\g<1>{version}\g<2>", content, count=1)
+    PYPROJECT.write_text(updated, encoding="utf-8")
+    print(f"[sync_version] Updated version: {current} → {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -32,7 +32,10 @@ def main() -> None:
     content = PYPROJECT.read_text(encoding="utf-8")
     match = VERSION_RE.search(content)
     if not match:
-        print(f"[sync_version] Could not find version field in {PYPROJECT}", file=sys.stderr)
+        print(
+            f"[sync_version] Could not find version field in {PYPROJECT}",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     current = match.group(0).split('"')[1]


### PR DESCRIPTION
## Summary
Add automated version synchronization during release workflows to keep `apps/indexed/pyproject.toml` in sync with git release tags.

## Changes
- **New tool**: `tools/sync_version.py` - Python script that:
  - Accepts a git tag (with or without 'v' prefix)
  - Validates the tag is valid semver format
  - Updates the version field in `apps/indexed/pyproject.toml`
  - Gracefully skips non-semver tags (allows workflow_dispatch on branch refs)
  - Provides clear logging of version changes

- **CI integration**: Updated `.github/workflows/python-release-ci.yml` to:
  - Run version sync immediately after dependency installation
  - Use `github.ref_name` to pass the release tag to the script
  - Fixed wheel attachment condition to use `always()` to ensure it runs even if previous steps fail

## Implementation Details
- Script uses regex to safely parse and update the version field in TOML
- Validates semver format (`\d+\.\d+\.\d+`) before making changes
- Exits successfully with warning for non-semver tags to prevent workflow failures
- Handles both `v0.1.0` and `0.1.0` tag formats transparently

https://claude.ai/code/session_01VXRGv4DhecFGajsGYdoMRB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process with automated version synchronization between package metadata and release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->