### PR TITLE
chore(security): remove pickle serialization and add path traversal protection

### DIFF
--- a/packages/indexed-core/src/core/v1/engine/core/documents_collection_creator.py
+++ b/packages/indexed-core/src/core/v1/engine/core/documents_collection_creator.py
@@ -372,10 +372,6 @@ class DocumentCollectionCreator:
                 indexer.get_faiss_index(),
                 f"{self.__build_index_base_path(indexer)}/indexer.faiss",
             )
-            # Also save legacy pickle format for backward compatibility
-            self.persister.save_bin_file(
-                indexer.serialize(), f"{self.__build_index_base_path(indexer)}/indexer"
-            )
 
         index_info = {
             "lastIndexItemId": last_index_item_id,

--- a/packages/indexed-core/src/core/v1/engine/indexes/indexer_factory.py
+++ b/packages/indexed-core/src/core/v1/engine/indexes/indexer_factory.py
@@ -85,9 +85,11 @@ def load_indexer(
             faiss_index = persister.read_faiss_index(native_path, mmap=True)
             logger.debug(f"Loaded FAISS index via mmap: {native_path}")
         elif persister.is_path_exists(legacy_path):
-            # Fall back to legacy pickle format
-            serialized_index = persister.read_bin_file(legacy_path)
-            logger.debug(f"Loaded FAISS index via legacy pickle: {legacy_path}")
+            raise ValueError(
+                f"Collection '{collection_name}' uses a legacy index format that is no "
+                "longer supported. Please re-index the collection with: "
+                "`indexed index update <collection-name>`"
+            )
         else:
             raise FileNotFoundError(
                 f"No FAISS index found at '{native_path}' or '{legacy_path}'"

--- a/packages/indexed-core/src/core/v1/engine/persisters/disk_persister.py
+++ b/packages/indexed-core/src/core/v1/engine/persisters/disk_persister.py
@@ -1,14 +1,20 @@
 import os
-import pickle
 import shutil
 
 
 class DiskPersister:
     def __init__(self, base_path):
-        self.base_path = base_path
+        self.base_path = os.path.realpath(base_path)
+
+    def _safe_join(self, *parts: str) -> str:
+        """Join path parts and verify the result stays within base_path."""
+        path = os.path.realpath(os.path.join(*parts))
+        if not path.startswith(self.base_path + os.sep) and path != self.base_path:
+            raise ValueError(f"Path escapes storage directory: {parts!r}")
+        return path
 
     def save_text_file(self, data, file_path):
-        path = os.path.join(self.base_path, file_path)
+        path = self._safe_join(self.base_path, file_path)
 
         self.__make_sure_path_exists(path)
 
@@ -16,30 +22,16 @@ class DiskPersister:
             file.write(data)
 
     def read_text_file(self, file_path):
-        path = os.path.join(self.base_path, file_path)
+        path = self._safe_join(self.base_path, file_path)
 
         with open(path, "r", encoding="utf-8") as file:
             return file.read()
-
-    def save_bin_file(self, data, file_path):
-        path = os.path.join(self.base_path, file_path)
-
-        self.__make_sure_path_exists(path)
-
-        with open(path, "wb") as file:
-            pickle.dump(data, file)
-
-    def read_bin_file(self, file_path):
-        path = os.path.join(self.base_path, file_path)
-
-        with open(path, "rb") as file:
-            return pickle.load(file)
 
     def save_faiss_index(self, faiss_index, file_path):
         """Save a FAISS index using native faiss.write_index for optimal I/O."""
         import faiss
 
-        path = os.path.join(self.base_path, file_path)
+        path = self._safe_join(self.base_path, file_path)
         self.__make_sure_path_exists(path)
         faiss.write_index(faiss_index, path)
 
@@ -52,36 +44,39 @@ class DiskPersister:
         """
         import faiss
 
-        path = os.path.join(self.base_path, file_path)
+        path = self._safe_join(self.base_path, file_path)
         io_flags = faiss.IO_FLAG_MMAP if mmap else 0
         return faiss.read_index(path, io_flags)
 
     def get_full_path(self, file_path):
         """Return the absolute path for a relative file path."""
-        return os.path.join(self.base_path, file_path)
+        return self._safe_join(self.base_path, file_path)
 
     def create_folder(self, folder_name):
-        directory_path = os.path.join(self.base_path, folder_name)
+        directory_path = self._safe_join(self.base_path, folder_name)
         os.makedirs(directory_path)
 
     def remove_folder(self, folder_name):
-        directory_path = os.path.join(self.base_path, folder_name)
+        directory_path = self._safe_join(self.base_path, folder_name)
 
         if os.path.exists(directory_path):
             shutil.rmtree(directory_path, ignore_errors=True)
 
     def remove_file(self, file_path):
-        path = os.path.join(self.base_path, file_path)
+        path = self._safe_join(self.base_path, file_path)
 
         if os.path.exists(path):
             os.remove(path)
 
     def is_path_exists(self, relative_path):
-        path = os.path.join(self.base_path, relative_path)
+        try:
+            path = self._safe_join(self.base_path, relative_path)
+        except ValueError:
+            return False
         return os.path.exists(path)
 
     def read_folder_files(self, relative_path):
-        path = os.path.join(self.base_path, relative_path)
+        path = self._safe_join(self.base_path, relative_path)
         files = []
         for root, dirs, filenames in os.walk(path):
             for filename in filenames:

--- a/packages/indexed-core/src/core/v1/engine/persisters/disk_persister.py
+++ b/packages/indexed-core/src/core/v1/engine/persisters/disk_persister.py
@@ -9,7 +9,7 @@ class DiskPersister:
     def _safe_join(self, *parts: str) -> str:
         """Join path parts and verify the result stays within base_path."""
         path = os.path.realpath(os.path.join(*parts))
-        if not path.startswith(self.base_path + os.sep) and path != self.base_path:
+        if os.path.commonpath([self.base_path, path]) != self.base_path:
             raise ValueError(f"Path escapes storage directory: {parts!r}")
         return path
 
@@ -18,8 +18,19 @@ class DiskPersister:
 
         self.__make_sure_path_exists(path)
 
-        with open(path, "w", encoding="utf-8") as file:
-            file.write(data)
+        tmp = path + ".tmp"
+        try:
+            with open(tmp, "w", encoding="utf-8") as file:
+                file.write(data)
+                file.flush()
+                os.fsync(file.fileno())
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
 
     def read_text_file(self, file_path):
         path = self._safe_join(self.base_path, file_path)
@@ -33,7 +44,16 @@ class DiskPersister:
 
         path = self._safe_join(self.base_path, file_path)
         self.__make_sure_path_exists(path)
-        faiss.write_index(faiss_index, path)
+        tmp = path + ".tmp"
+        try:
+            faiss.write_index(faiss_index, tmp)
+            os.replace(tmp, path)
+        except Exception:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
 
     def read_faiss_index(self, file_path, mmap=True):
         """Load a FAISS index using native faiss.read_index.

--- a/packages/indexed-parsing/src/parsing/__init__.py
+++ b/packages/indexed-parsing/src/parsing/__init__.py
@@ -6,6 +6,7 @@ to provide a single ``ParsingModule.parse()`` entry-point.
 
 from __future__ import annotations
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -76,12 +77,11 @@ class ParsingModule:
     def parse_bytes(self, data: bytes, filename: str) -> ParsedDocument:
         """Parse in-memory bytes (e.g. from Confluence attachments)."""
         suffix = Path(filename).suffix
-        with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-            tmp.write(data)
-            tmp.flush()
-            tmp_path = Path(tmp.name)
-
+        fd, tmp_name = tempfile.mkstemp(suffix=suffix)
+        tmp_path = Path(tmp_name)
         try:
+            with os.fdopen(fd, "wb") as tmp:
+                tmp.write(data)
             doc = self.parse(tmp_path)
             # Replace temp path with the original filename
             doc.file_path = filename

--- a/tests/unit/indexed_core/test_disk_persister.py
+++ b/tests/unit/indexed_core/test_disk_persister.py
@@ -1,104 +1,141 @@
-"""Tests for DiskPersister path safety and file operations."""
+"""Tests for DiskPersister path safety, atomic writes, and file operations."""
 
-import os
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import pytest
+
+from core.v1.engine.persisters.disk_persister import DiskPersister
+
+
+@pytest.fixture
+def disk_persister(tmp_path: Path) -> DiskPersister:
+    """Return a DiskPersister rooted at a fresh temp directory."""
+    return DiskPersister(str(tmp_path))
 
 
 class TestDiskPersisterPathSafety:
-    def test_safe_join_allows_valid_path(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
+    """Verify that _safe_join rejects paths that escape base_path."""
 
-        p = DiskPersister(str(tmp_path))
-        result = p._safe_join(str(tmp_path), "subdir/file.txt")
+    def test_safe_join_allows_valid_path(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """Valid relative paths resolve inside base_path."""
+        result = disk_persister._safe_join(str(tmp_path), "subdir/file.txt")
         assert result.startswith(str(tmp_path))
 
-    def test_safe_join_rejects_traversal(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
+    def test_safe_join_rejects_traversal(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """Paths using ../ that escape base_path raise ValueError."""
         with pytest.raises(ValueError, match="Path escapes"):
-            p._safe_join(str(tmp_path), "../../etc/passwd")
+            disk_persister._safe_join(str(tmp_path), "../../etc/passwd")
 
-    def test_safe_join_rejects_absolute_escape(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
+    def test_safe_join_rejects_absolute_escape(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """Absolute paths outside base_path raise ValueError."""
         with pytest.raises(ValueError, match="Path escapes"):
-            p._safe_join(str(tmp_path), "/etc/passwd")
+            disk_persister._safe_join(str(tmp_path), "/etc/passwd")
 
-    def test_is_path_exists_returns_false_for_traversal(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
+    def test_is_path_exists_returns_false_for_traversal(
+        self, disk_persister: DiskPersister
+    ) -> None:
+        """Path traversal attempts return False rather than raising."""
+        assert disk_persister.is_path_exists("../../etc/passwd") is False
 
-        p = DiskPersister(str(tmp_path))
-        assert p.is_path_exists("../../etc/passwd") is False
-
-    def test_save_and_read_text_file(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
-        p.save_text_file("hello", "test.txt")
-        assert p.read_text_file("test.txt") == "hello"
-
-    def test_save_text_file_rejects_traversal(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
+    def test_save_text_file_rejects_traversal(
+        self, disk_persister: DiskPersister
+    ) -> None:
+        """save_text_file raises ValueError for traversal paths."""
         with pytest.raises(ValueError, match="Path escapes"):
-            p.save_text_file("bad", "../outside.txt")
+            disk_persister.save_text_file("bad", "../outside.txt")
 
-    def test_create_and_remove_folder(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
-        p.create_folder("mydir")
-        assert os.path.isdir(tmp_path / "mydir")
-        p.remove_folder("mydir")
-        assert not os.path.exists(tmp_path / "mydir")
-
-    def test_remove_file(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
-        p.save_text_file("data", "f.txt")
-        p.remove_file("f.txt")
-        assert not os.path.exists(tmp_path / "f.txt")
-
-    def test_get_full_path(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
-        result = p.get_full_path("a/b.txt")
-        assert result == str(tmp_path / "a" / "b.txt")
-
-    def test_read_folder_files(self, tmp_path):
-        from core.v1.engine.persisters.disk_persister import DiskPersister
-
-        p = DiskPersister(str(tmp_path))
-        p.save_text_file("x", "sub/a.txt")
-        p.save_text_file("y", "sub/b.txt")
-        files = p.read_folder_files("sub")
-        assert sorted(files) == ["a.txt", "b.txt"]
-
-    def test_no_pickle_import(self):
+    def test_no_pickle_import(self) -> None:
+        """pickle must not be imported in disk_persister."""
         import core.v1.engine.persisters.disk_persister as mod
 
-        assert not hasattr(mod, "pickle"), (
-            "pickle must not be imported in disk_persister"
-        )
+        assert not hasattr(mod, "pickle")
+
+
+class TestDiskPersisterFileOperations:
+    """Basic file and folder operations."""
+
+    def test_save_and_read_text_file(self, disk_persister: DiskPersister) -> None:
+        """Round-trip through save_text_file / read_text_file."""
+        disk_persister.save_text_file("hello", "test.txt")
+        assert disk_persister.read_text_file("test.txt") == "hello"
+
+    def test_save_text_file_is_atomic(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """No .tmp file remains after a successful save."""
+        disk_persister.save_text_file("content", "out.txt")
+        assert (tmp_path / "out.txt").read_text() == "content"
+        assert not any(tmp_path.glob("*.tmp"))
+
+    def test_save_text_file_cleans_up_tmp_on_error(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """When os.replace fails the .tmp file is cleaned up."""
+        with patch("os.replace", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                disk_persister.save_text_file("data", "file.txt")
+        assert not any(tmp_path.glob("*.tmp"))
+
+    def test_create_and_remove_folder(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """create_folder creates the directory; remove_folder deletes it."""
+        disk_persister.create_folder("mydir")
+        assert (tmp_path / "mydir").is_dir()
+        disk_persister.remove_folder("mydir")
+        assert not (tmp_path / "mydir").exists()
+
+    def test_remove_file(self, disk_persister: DiskPersister, tmp_path: Path) -> None:
+        """remove_file deletes an existing file."""
+        disk_persister.save_text_file("data", "f.txt")
+        disk_persister.remove_file("f.txt")
+        assert not (tmp_path / "f.txt").exists()
+
+    def test_get_full_path(self, disk_persister: DiskPersister, tmp_path: Path) -> None:
+        """get_full_path returns the real absolute path."""
+        result = disk_persister.get_full_path("a/b.txt")
+        assert result == str(tmp_path / "a" / "b.txt")
+
+    def test_read_folder_files(self, disk_persister: DiskPersister) -> None:
+        """read_folder_files lists relative paths of files in a subfolder."""
+        disk_persister.save_text_file("x", "sub/a.txt")
+        disk_persister.save_text_file("y", "sub/b.txt")
+        assert sorted(disk_persister.read_folder_files("sub")) == ["a.txt", "b.txt"]
 
 
 class TestDiskPersisterLegacyIndexError:
-    def test_load_indexer_raises_on_legacy_pickle_file(self, tmp_path):
-        from unittest.mock import MagicMock
+    """load_indexer must reject legacy pickle-format indexes."""
 
-        from core.v1.engine.indexes.indexer_factory import load_indexer
+    def test_load_indexer_raises_on_legacy_pickle_file(self, tmp_path: Path) -> None:
+        """ValueError is raised when only the legacy 'indexer' file exists."""
+        from types import SimpleNamespace
+
+        import core.v1.engine.indexes.indexer_factory as factory
 
         persister = MagicMock()
         persister.is_path_exists.side_effect = lambda path: path.endswith("/indexer")
 
-        with pytest.raises(ValueError, match="legacy index format"):
-            load_indexer(
-                "indexer_FAISS_IndexFlatL2__embeddings_all-MiniLM-L6-v2",
-                "my-collection",
-                persister,
-            )
+        dummy_config = SimpleNamespace(model_name="dummy-model")
+
+        with (
+            patch.object(factory, "get_indexer_config", return_value=dummy_config),
+            patch(
+                "core.v1.engine.indexes.embeddings.sentence_embeder.SentenceEmbedder",
+                return_value=MagicMock(),
+            ),
+        ):
+            with pytest.raises(ValueError, match="legacy index format"):
+                factory.load_indexer(
+                    "indexer_FAISS_IndexFlatL2__embeddings_all-MiniLM-L6-v2",
+                    "my-collection",
+                    persister,
+                )

--- a/tests/unit/indexed_core/test_disk_persister.py
+++ b/tests/unit/indexed_core/test_disk_persister.py
@@ -82,7 +82,9 @@ class TestDiskPersisterPathSafety:
     def test_no_pickle_import(self):
         import core.v1.engine.persisters.disk_persister as mod
 
-        assert not hasattr(mod, "pickle"), "pickle must not be imported in disk_persister"
+        assert not hasattr(mod, "pickle"), (
+            "pickle must not be imported in disk_persister"
+        )
 
 
 class TestDiskPersisterLegacyIndexError:

--- a/tests/unit/indexed_core/test_disk_persister.py
+++ b/tests/unit/indexed_core/test_disk_persister.py
@@ -112,6 +112,56 @@ class TestDiskPersisterFileOperations:
         assert sorted(disk_persister.read_folder_files("sub")) == ["a.txt", "b.txt"]
 
 
+class TestDiskPersisterFaissOperations:
+    """save_faiss_index and read_faiss_index use native faiss I/O atomically."""
+
+    def test_save_faiss_index_is_atomic(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """save_faiss_index writes via tmp then renames; no .tmp remains."""
+        mock_faiss = MagicMock()
+        with patch.dict("sys.modules", {"faiss": mock_faiss}), patch("os.replace"):
+            disk_persister.save_faiss_index(MagicMock(), "idx.faiss")
+        assert mock_faiss.write_index.called
+        assert not any(tmp_path.glob("*.tmp"))
+
+    def test_save_faiss_index_cleans_up_on_error(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """When faiss.write_index raises the .tmp file is cleaned up."""
+        mock_faiss = MagicMock()
+        mock_faiss.write_index.side_effect = OSError("no space")
+        with patch.dict("sys.modules", {"faiss": mock_faiss}):
+            with pytest.raises(OSError, match="no space"):
+                disk_persister.save_faiss_index(MagicMock(), "idx.faiss")
+        assert not any(tmp_path.glob("*.tmp"))
+
+    def test_read_faiss_index_mmap(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """read_faiss_index calls faiss.read_index with mmap flag."""
+        mock_faiss = MagicMock()
+        mock_faiss.IO_FLAG_MMAP = 2
+        (tmp_path / "idx.faiss").write_bytes(b"")
+        with patch.dict("sys.modules", {"faiss": mock_faiss}):
+            disk_persister.read_faiss_index("idx.faiss", mmap=True)
+        mock_faiss.read_index.assert_called_once()
+        _, flags = mock_faiss.read_index.call_args[0]
+        assert flags == 2
+
+    def test_read_faiss_index_no_mmap(
+        self, disk_persister: DiskPersister, tmp_path: Path
+    ) -> None:
+        """read_faiss_index passes 0 as flags when mmap=False."""
+        mock_faiss = MagicMock()
+        mock_faiss.IO_FLAG_MMAP = 2
+        (tmp_path / "idx.faiss").write_bytes(b"")
+        with patch.dict("sys.modules", {"faiss": mock_faiss}):
+            disk_persister.read_faiss_index("idx.faiss", mmap=False)
+        _, flags = mock_faiss.read_index.call_args[0]
+        assert flags == 0
+
+
 class TestDiskPersisterLegacyIndexError:
     """load_indexer must reject legacy pickle-format indexes."""
 

--- a/tests/unit/indexed_core/test_disk_persister.py
+++ b/tests/unit/indexed_core/test_disk_persister.py
@@ -1,0 +1,102 @@
+"""Tests for DiskPersister path safety and file operations."""
+
+import os
+import pytest
+
+
+class TestDiskPersisterPathSafety:
+    def test_safe_join_allows_valid_path(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        result = p._safe_join(str(tmp_path), "subdir/file.txt")
+        assert result.startswith(str(tmp_path))
+
+    def test_safe_join_rejects_traversal(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        with pytest.raises(ValueError, match="Path escapes"):
+            p._safe_join(str(tmp_path), "../../etc/passwd")
+
+    def test_safe_join_rejects_absolute_escape(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        with pytest.raises(ValueError, match="Path escapes"):
+            p._safe_join(str(tmp_path), "/etc/passwd")
+
+    def test_is_path_exists_returns_false_for_traversal(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        assert p.is_path_exists("../../etc/passwd") is False
+
+    def test_save_and_read_text_file(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        p.save_text_file("hello", "test.txt")
+        assert p.read_text_file("test.txt") == "hello"
+
+    def test_save_text_file_rejects_traversal(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        with pytest.raises(ValueError, match="Path escapes"):
+            p.save_text_file("bad", "../outside.txt")
+
+    def test_create_and_remove_folder(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        p.create_folder("mydir")
+        assert os.path.isdir(tmp_path / "mydir")
+        p.remove_folder("mydir")
+        assert not os.path.exists(tmp_path / "mydir")
+
+    def test_remove_file(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        p.save_text_file("data", "f.txt")
+        p.remove_file("f.txt")
+        assert not os.path.exists(tmp_path / "f.txt")
+
+    def test_get_full_path(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        result = p.get_full_path("a/b.txt")
+        assert result == str(tmp_path / "a" / "b.txt")
+
+    def test_read_folder_files(self, tmp_path):
+        from core.v1.engine.persisters.disk_persister import DiskPersister
+
+        p = DiskPersister(str(tmp_path))
+        p.save_text_file("x", "sub/a.txt")
+        p.save_text_file("y", "sub/b.txt")
+        files = p.read_folder_files("sub")
+        assert sorted(files) == ["a.txt", "b.txt"]
+
+    def test_no_pickle_import(self):
+        import core.v1.engine.persisters.disk_persister as mod
+
+        assert not hasattr(mod, "pickle"), "pickle must not be imported in disk_persister"
+
+
+class TestDiskPersisterLegacyIndexError:
+    def test_load_indexer_raises_on_legacy_pickle_file(self, tmp_path):
+        from unittest.mock import MagicMock
+
+        from core.v1.engine.indexes.indexer_factory import load_indexer
+
+        persister = MagicMock()
+        persister.is_path_exists.side_effect = lambda path: path.endswith("/indexer")
+
+        with pytest.raises(ValueError, match="legacy index format"):
+            load_indexer(
+                "indexer_FAISS_IndexFlatL2__embeddings_all-MiniLM-L6-v2",
+                "my-collection",
+                persister,
+            )


### PR DESCRIPTION
## Summary

This PR removes pickle-based binary serialization from the disk persister and implements path traversal attack prevention across all file operations. It also removes support for legacy pickle-format FAISS indexes, requiring users to re-index collections using the new native FAISS format.

## Key Changes

- **Security**: Added `_safe_join()` method to `DiskPersister` that validates all file paths stay within the base storage directory, preventing directory traversal attacks via `..` sequences
- **Removed pickle serialization**: Deleted `save_bin_file()` and `read_bin_file()` methods that used Python's pickle module for binary serialization
- **Legacy format deprecation**: Replaced fallback to legacy pickle-format FAISS indexes with a clear error message directing users to re-index their collections
- **Removed backward compatibility code**: Deleted code that saved FAISS indexes in both native and legacy pickle formats during indexing
- **Applied path validation**: Updated all file operations (`save_text_file`, `read_text_file`, `save_faiss_index`, `read_faiss_index`, `get_full_path`, `create_folder`, `remove_folder`, `remove_file`, `is_path_exists`, `read_folder_files`) to use the new `_safe_join()` method
- **Improved temp file handling**: Refactored `parse_bytes()` in the parsing module to use `tempfile.mkstemp()` with explicit file descriptor management instead of `NamedTemporaryFile`, improving resource handling

## Implementation Details

- `_safe_join()` uses `os.path.realpath()` to resolve symlinks and normalize paths before validation
- Path validation checks that the resolved path either equals the base path or starts with `base_path + os.sep` to prevent prefix matching attacks
- `is_path_exists()` gracefully handles path traversal attempts by catching `ValueError` and returning `False`
- The deprecation error for legacy indexes provides clear guidance on how to migrate: `indexed index update <collection-name>`