### PR TITLE
fix(connectors): address PR #87 review comments

### DIFF
--- a/apps/indexed/src/indexed/knowledge/commands/_create_helpers.py
+++ b/apps/indexed/src/indexed/knowledge/commands/_create_helpers.py
@@ -123,12 +123,15 @@ def execute_create_command(
             len(validation.missing),
         )
 
+    # Phase 1b: Apply CLI credential overrides before prompting so connector
+    # prompt logic can see tokens already provided on the command line.
+    apply_cli_credential_overrides(source_type, cli_overrides)
+
     # Phase 1: Prompt for missing values using connector-specific callback
     if validation.missing:
         prompt_missing_fields(validation, config, namespace)
 
-    # Phase 1b: Ensure credentials (interactive prompt + .env persistence)
-    apply_cli_credential_overrides(source_type, cli_overrides)
+    # Phase 1c: Ensure credentials (interactive prompt + .env persistence)
     ensure_credentials_for_source(source_type, config, namespace=namespace)
 
     # Also set CLI overrides in config for connector to read

--- a/apps/indexed/src/indexed/knowledge/commands/_create_helpers.py
+++ b/apps/indexed/src/indexed/knowledge/commands/_create_helpers.py
@@ -11,7 +11,7 @@ from loguru import logger
 if TYPE_CHECKING:
     from core.v1.engine.services import SourceConfig
 
-from indexed_config import ConfigService
+from indexed_config import ConfigService, ValidationResult
 
 from ...utils.logging import is_verbose_mode, setup_root_logger
 from ...utils.console import console
@@ -32,7 +32,7 @@ def execute_create_command(
     config_class: Type,
     namespace: str,
     cli_overrides: Dict[str, Any],
-    prompt_missing_fields: Callable[[Dict[str, Any], ConfigService, str], None],
+    prompt_missing_fields: Callable[[ValidationResult, ConfigService, str], None],
     build_source_config: Callable[[Dict[str, Any], str], "SourceConfig"],
     success_message_suffix: str,
     verbose: bool,

--- a/apps/indexed/src/indexed/knowledge/commands/create.py
+++ b/apps/indexed/src/indexed/knowledge/commands/create.py
@@ -9,7 +9,7 @@ import typer
 from loguru import logger
 
 # Import ConfigService at module level so tests can patch
-from indexed_config import ConfigService
+from indexed_config import ConfigService, ValidationResult
 
 # Import utilities for progress and logging
 from ...utils.logging import is_verbose_mode
@@ -164,7 +164,7 @@ def create_files(
     cli_overrides["respect_gitignore"] = respect_gitignore
 
     def prompt_missing_files_fields(
-        validation: Dict[str, Any], config: ConfigService, ns: str
+        validation: ValidationResult, config: ConfigService, ns: str
     ) -> None:
         """Prompt for missing Files-specific fields."""
         if not validation.missing:
@@ -392,7 +392,7 @@ def create_jira(
         cli_overrides["api_token"] = token
 
     def prompt_missing_jira_fields(
-        validation: Dict[str, Any], config: ConfigService, ns: str
+        validation: ValidationResult, config: ConfigService, ns: str
     ) -> None:
         """Prompt for missing Jira-specific fields."""
         # URL already handled above, exclude it from missing fields
@@ -622,7 +622,7 @@ def create_confluence(
     cli_overrides["read_all_comments"] = read_all_comments
 
     def prompt_missing_confluence_fields(
-        validation: Dict[str, Any], config: ConfigService, ns: str
+        validation: ValidationResult, config: ConfigService, ns: str
     ) -> None:
         """Prompt for missing Confluence-specific fields."""
         # URL already handled above, exclude it from missing fields
@@ -850,7 +850,7 @@ def create_outline(
     cli_overrides["ocr_enabled"] = ocr
 
     def prompt_missing_outline_fields(
-        validation: Dict[str, Any], cfg: ConfigService, ns: str
+        validation: ValidationResult, cfg: ConfigService, ns: str
     ) -> None:
         missing_fields = [f for f in validation.missing if f not in ("url",)]
         if not missing_fields:

--- a/docs/specs/outline-connector-product.md
+++ b/docs/specs/outline-connector-product.md
@@ -39,16 +39,16 @@ Teams that run [Outline](https://www.getoutline.com/) as their primary knowledge
 
 ### 1. Index an Outline Cloud workspace
 
-```
-$ indexed index create outline --collection company-wiki
+```bash
+$ indexed index create outline --collection outline-wiki
 Outline URL [https://app.getoutline.com]: ↵
 Outline API Token: ••••••••••••••
-✓ Collection 'company-wiki' created with 342 documents from Outline
+✓ Collection 'outline-wiki' created with 342 documents from Outline
 ```
 
 ### 2. Index a self-hosted Outline instance
 
-```
+```bash
 $ indexed index create outline --collection internal-wiki
 Outline URL [https://app.getoutline.com]: https://wiki.acme.internal
 Outline API Token: ••••••••••••••
@@ -59,15 +59,15 @@ The user experience is identical to Cloud; only the URL prompt answer differs.
 
 ### 3. Search Outline content via CLI
 
-```
-$ indexed index search "incident runbook pagerduty" --collection company-wiki
+```bash
+$ indexed index search "incident runbook pagerduty" --collection outline-wiki
 ```
 
 Results include Outline URLs, document titles, and the matching text passage.
 
 ### 4. AI agent searches Outline via MCP
 
-An AI agent calling `search(query="deploy backend service", collection="company-wiki")` via the MCP server receives the most relevant Outline passages, including text extracted from embedded screenshots via OCR.
+An AI agent calling `search(query="deploy backend service", collection="outline-wiki")` via the MCP server receives the most relevant Outline passages, including text extracted from embedded screenshots via OCR.
 
 ### 5. Restrict indexing to specific collections
 
@@ -79,8 +79,8 @@ Scopes indexing to the specified Outline collection IDs instead of the whole wor
 
 ### 6. Incremental update
 
-```
-$ indexed index update company-wiki
+```bash
+$ indexed index update outline-wiki
 ```
 
 Re-fetches only documents with `updatedAt > last_indexed_at`, re-embeds changed chunks, and updates the FAISS index in place.
@@ -95,7 +95,7 @@ collection_ids = ["abc123"]
 include_attachments = true
 ```
 
-```
+```bash
 $ export OUTLINE_API_TOKEN=ol_api_...
 $ indexed index create outline --collection ops-wiki
 ```

--- a/docs/specs/outline-connector-product.md
+++ b/docs/specs/outline-connector-product.md
@@ -72,7 +72,7 @@ An AI agent calling `search(query="deploy backend service", collection="company-
 ### 5. Restrict indexing to specific collections
 
 ```
-$ indexed index create outline --collection eng-wiki --collection-id abc123,def456
+$ indexed index create outline --collection eng-wiki --collection-id abc123 --collection-id def456
 ```
 
 Scopes indexing to the specified Outline collection IDs instead of the whole workspace.
@@ -110,7 +110,7 @@ $ indexed index create outline --collection ops-wiki
 |------|---------|-------------|
 | `--url` / `-u` | prompted (default `https://app.getoutline.com`) | Outline base URL. Accepts any domain for self-hosted. |
 | `--token` | prompted (env `OUTLINE_API_TOKEN`) | Outline API token (`ol_api_…`). Stored in `.env`. |
-| `--collection-id` | (index all) | Comma-separated collection IDs to restrict indexing. |
+| `--collection-id` | (index all) | Repeatable flag; each value is a single collection ID to restrict indexing. |
 | `--include-attachments / --no-include-attachments` | `True` | Download and OCR attachments and inline images. |
 | `--ocr / --no-ocr` | `True` | Enable OCR on image attachments. |
 | `--collection` / `-c` | `outline` | Name for the indexed collection. |

--- a/docs/specs/outline-connector-tech.md
+++ b/docs/specs/outline-connector-tech.md
@@ -10,7 +10,7 @@
 
 The Outline connector follows the same three-file structure as every other connector in `packages/indexed-connectors/`:
 
-```
+```text
 packages/indexed-connectors/src/connectors/outline/
 ├── __init__.py                    # Public re-exports
 ├── schema.py                      # OutlineConfig (Pydantic)
@@ -94,7 +94,7 @@ class OutlineConfig(BaseModel):
 
 Mirrors `async_confluence_cloud_reader.py` exactly — sequential page listing, concurrent document body + attachment fetching within sliding windows:
 
-```
+```text
 Phase 1 (sequential):  collections.list  →  per-collection documents.list (paginated)
 Phase 2 (windowed):    buffer 100 doc stubs
                        asyncio.gather → documents.info  (body + metadata)
@@ -168,15 +168,18 @@ Mirrors `unified_confluence_document_converter.py` but operates on Markdown dire
 
 ```python
 class OutlineDocumentConverter:
-    def convert(self, document: dict) -> list[dict]:
+    def convert(self, document: dict) -> Iterator[dict]:
+        """Yields one dict per document with source metadata on every chunk."""
         doc = document["document"]
-        return [{
+        yield {
             "id": doc["id"],
-            "url": doc["url"],
-            "modifiedTime": doc["updatedAt"],
+            "url": doc.get("url", ""),
+            "modifiedTime": self._resolve_modified_time(doc),
             "text": self._build_full_text(document),
             "chunks": self._split_to_chunks(document),
-        }]
+            # Each chunk dict carries: indexedData, metadata (sourceId,
+            # sourceUrl, sourceUpdatedAt, plus parser/attachment metadata).
+        }
 ```
 
 ### Title hierarchy
@@ -267,7 +270,7 @@ indexed index create outline \
   --collection wiki \
   --url https://app.getoutline.com \
   --token ol_api_... \
-  [--collection-id abc123,def456] \
+  [--collection-id abc123 --collection-id def456] \
   [--include-attachments] \
   [--no-ocr] \
   [--force] [--use-cache] [--local] [--verbose]
@@ -279,7 +282,7 @@ indexed index create outline \
 2. `Outline API Token:` — masked, stored in `.env`.
 
 **Verbose log lines:**
-```
+```text
 INFO  Connecting to Outline at https://app.getoutline.com (Cloud)
 INFO  Connecting to Outline at https://wiki.acme.internal (self-hosted)
 ```

--- a/docs/specs/outline-connector-tech.md
+++ b/docs/specs/outline-connector-tech.md
@@ -184,14 +184,11 @@ class OutlineDocumentConverter:
 Outline documents carry a `parentDocumentId` field. The reader pre-builds a `{id: title}` map per collection so the converter can walk ancestors cheaply:
 
 ```python
-def _build_title_path(self, doc: dict, title_map: dict[str, str]) -> str:
-    parts: list[str] = []
-    parent_id = doc.get("parentDocumentId")
-    while parent_id and parent_id in title_map:
-        parts.insert(0, title_map[parent_id])
-        parent_id = None  # Outline only provides direct parent in documents.list
-    parts.append(doc["title"])
-    return " -> ".join(parts)
+@staticmethod
+def _build_title_path(doc: dict) -> str:
+    # Outline's documents.info does not return ancestor titles —
+    # a full ancestor walk requires a pre-built title map (deferred to a follow-up).
+    return str(doc.get("title", ""))
 ```
 
 ### Chunking

--- a/packages/indexed-connectors/src/connectors/outline/outline_document_converter.py
+++ b/packages/indexed-connectors/src/connectors/outline/outline_document_converter.py
@@ -8,7 +8,7 @@ no BeautifulSoup HTML stripping needed since Outline bodies are already Markdown
 from __future__ import annotations
 
 import base64
-from typing import Any
+from typing import Any, Iterator
 
 from loguru import logger
 
@@ -51,27 +51,25 @@ class OutlineDocumentConverter:
     # Public API
     # ------------------------------------------------------------------
 
-    def convert(self, document: dict) -> list[dict]:
+    def convert(self, document: dict) -> Iterator[dict]:
         """Convert an Outline document dict to indexed format.
 
         Args:
             document: Dict with "document" (full Outline API doc dict) and
                       "attachments" (list of downloaded attachment dicts).
 
-        Returns:
-            Single-element list with id, url, modifiedTime, text, chunks.
+        Yields:
+            Single dict with id, url, modifiedTime, text, chunks.
         """
         doc = document["document"]
 
-        return [
-            {
-                "id": doc["id"],
-                "url": self._build_url(doc),
-                "modifiedTime": self._resolve_modified_time(doc),
-                "text": self._build_full_text(document),
-                "chunks": self._split_to_chunks(document),
-            }
-        ]
+        yield {
+            "id": doc["id"],
+            "url": self._build_url(doc),
+            "modifiedTime": self._resolve_modified_time(doc),
+            "text": self._build_full_text(document),
+            "chunks": self._split_to_chunks(document),
+        }
 
     # ------------------------------------------------------------------
     # Text helpers
@@ -117,10 +115,19 @@ class OutlineDocumentConverter:
 
     def _split_to_chunks(self, document: dict) -> list[dict]:
         doc = document["document"]
+        src_meta = {
+            "sourceId": doc.get("id"),
+            "sourceUrl": self._build_url(doc),
+            "sourceUpdatedAt": self._resolve_modified_time(doc),
+        }
 
         # First chunk: title (gives search context)
         title_path = self._build_title_path(doc)
-        chunks: list[dict] = [{"indexedData": title_path}] if title_path else []
+        chunks: list[dict] = (
+            [{"indexedData": title_path, "metadata": dict(src_meta)}]
+            if title_path
+            else []
+        )
 
         # Chunk body via ParsingModule
         body = doc.get("text", "")
@@ -129,22 +136,23 @@ class OutlineDocumentConverter:
                 parsed = self._parser.parse_bytes(body.encode("utf-8"), "doc.md")
                 for chunk in parsed.chunks:
                     entry: dict = {"indexedData": chunk.contextualized_text}
-                    if chunk.metadata:
-                        entry["metadata"] = dict(chunk.metadata)
+                    meta = dict(chunk.metadata) if chunk.metadata else {}
+                    meta.update(src_meta)
+                    entry["metadata"] = meta
                     chunks.append(entry)
             except Exception as exc:
                 logger.warning(
                     "Failed to parse body of doc {}: {}", doc.get("id", "?"), exc
                 )
-                chunks.append({"indexedData": body})
+                chunks.append({"indexedData": body, "metadata": dict(src_meta)})
 
         # Chunk attachments if enabled
         if self._include_attachments:
-            chunks.extend(self._parse_attachments(document))
+            chunks.extend(self._parse_attachments(document, src_meta))
 
         return chunks
 
-    def _parse_attachments(self, document: dict) -> list[dict]:
+    def _parse_attachments(self, document: dict, src_meta: dict) -> list[dict]:
         """Parse attachment bytes via ParsingModule."""
         attachment_chunks: list[dict] = []
         attachments = document.get("attachments", [])
@@ -171,6 +179,7 @@ class OutlineDocumentConverter:
                     entry: dict = {"indexedData": chunk.contextualized_text}
                     meta = dict(chunk.metadata) if chunk.metadata else {}
                     meta["attachment"] = filename
+                    meta.update(src_meta)
                     entry["metadata"] = meta
                     attachment_chunks.append(entry)
             except Exception:

--- a/packages/indexed-connectors/src/connectors/outline/outline_document_reader.py
+++ b/packages/indexed-connectors/src/connectors/outline/outline_document_reader.py
@@ -144,6 +144,10 @@ class OutlineDocumentReader:
             "collectionIds": self.collection_ids,
             "batchSize": self.batch_size,
             "includeAttachments": self.include_attachments,
+            "downloadInlineImages": self.download_inline_images,
+            "maxConcurrentRequests": self.max_concurrent_requests,
+            "maxAttachmentSizeMb": self.max_attachment_size_bytes // (1024 * 1024),
+            "verifySsl": self.verify_ssl,
             "ocrEnabled": self.ocr_enabled,
         }
 
@@ -182,7 +186,7 @@ class OutlineDocumentReader:
 
     def _get_collection_ids_sync(self) -> list[str]:
         """Return collection IDs to index — from config or by listing all."""
-        if self.collection_ids:
+        if self.collection_ids is not None:
             return self.collection_ids
 
         ids: list[str] = []
@@ -328,7 +332,19 @@ class OutlineDocumentReader:
         # Inline images embedded in the Markdown body
         if self.include_attachments and self.download_inline_images:
             text = doc.get("text", "")
+            base_origin = urlparse(self.base_url)
             for url in _INLINE_IMAGE_RE.findall(text):
+                parsed_url = urlparse(url)
+                if (parsed_url.scheme, parsed_url.netloc) != (
+                    base_origin.scheme,
+                    base_origin.netloc,
+                ):
+                    logger.warning(
+                        "Skipping cross-origin inline attachment URL for doc {}: {}",
+                        doc_id,
+                        url,
+                    )
+                    continue
                 att_id = self._extract_attachment_id(url)
                 if att_id and att_id not in seen_ids:
                     seen_ids.add(att_id)

--- a/packages/indexed-connectors/src/connectors/outline/outline_document_reader.py
+++ b/packages/indexed-connectors/src/connectors/outline/outline_document_reader.py
@@ -123,27 +123,18 @@ class OutlineDocumentReader:
         if self._modified_since_cutoff is not None:
             return sum(1 for _ in self._iter_document_stubs())
 
-        import requests  # type: ignore[import-untyped]
-
         total = 0
         for cid in self._get_collection_ids_sync():
-            offset = 0
-            while True:
-                resp = requests.post(
-                    f"{self.base_url}/api/documents.list",
-                    headers=self._auth_headers,
-                    json={
-                        "collectionId": cid,
-                        "status": "published",
-                        "limit": 1,
-                        "offset": offset,
-                    },
-                    verify=self.verify_ssl,
-                )
-                resp.raise_for_status()
-                data = resp.json()
-                total += data.get("pagination", {}).get("total", 0)
-                break
+            resp = self._post_with_retry(
+                f"{self.base_url}/api/documents.list",
+                {
+                    "collectionId": cid,
+                    "status": "published",
+                    "limit": 1,
+                    "offset": 0,
+                },
+            )
+            total += resp.json().get("pagination", {}).get("total", 0)
         return total
 
     def get_reader_details(self) -> dict:
@@ -162,37 +153,14 @@ class OutlineDocumentReader:
 
     def _iter_document_stubs(self) -> Iterator[dict]:
         """Yield minimal document stubs (id, title, updatedAt, etc.) for all collections."""
-        import requests  # type: ignore[import-untyped]
-
         for collection_id in self._get_collection_ids_sync():
             offset = 0
             logger.debug("Listing documents in collection {}", collection_id)
             while True:
-                for attempt in range(self.number_of_retries):
-                    try:
-                        resp = requests.post(
-                            f"{self.base_url}/api/documents.list",
-                            headers=self._auth_headers,
-                            json=self._documents_list_payload(collection_id, offset),
-                            verify=self.verify_ssl,
-                        )
-                        self._raise_for_status(resp)
-                        break
-                    except OutlineAPIError:
-                        raise
-                    except Exception as exc:
-                        if attempt == self.number_of_retries - 1:
-                            raise
-                        logger.debug(
-                            "Retry {}/{} listing docs: {}",
-                            attempt + 1,
-                            self.number_of_retries,
-                            exc,
-                        )
-                        import time
-
-                        time.sleep(self.retry_delay * (2**attempt))
-
+                resp = self._post_with_retry(
+                    f"{self.base_url}/api/documents.list",
+                    self._documents_list_payload(collection_id, offset),
+                )
                 result = resp.json()
                 docs = result.get("data", [])
                 pagination = result.get("pagination", {})
@@ -217,18 +185,13 @@ class OutlineDocumentReader:
         if self.collection_ids:
             return self.collection_ids
 
-        import requests  # type: ignore[import-untyped]
-
         ids: list[str] = []
         offset = 0
         while True:
-            resp = requests.post(
+            resp = self._post_with_retry(
                 f"{self.base_url}/api/collections.list",
-                headers=self._auth_headers,
-                json={"limit": 100, "offset": offset},
-                verify=self.verify_ssl,
+                {"limit": 100, "offset": offset},
             )
-            self._raise_for_status(resp)
             result = resp.json()
             collections = result.get("data", [])
             ids.extend(c["id"] for c in collections)
@@ -248,7 +211,7 @@ class OutlineDocumentReader:
         """Fetch full docs (and optionally attachments) for a window of stubs."""
         full_docs = asyncio.run(self._fetch_bodies_async(stubs))
         attachments_map: dict[int, list[dict]] = {}
-        if self.include_attachments or self.download_inline_images:
+        if self.include_attachments:
             attachments_map = asyncio.run(self._fetch_attachments_async(full_docs))
 
         for i, doc in enumerate(full_docs):
@@ -363,7 +326,7 @@ class OutlineDocumentReader:
                     downloaded.append(data)
 
         # Inline images embedded in the Markdown body
-        if self.download_inline_images:
+        if self.include_attachments and self.download_inline_images:
             text = doc.get("text", "")
             for url in _INLINE_IMAGE_RE.findall(text):
                 att_id = self._extract_attachment_id(url)
@@ -503,6 +466,45 @@ class OutlineDocumentReader:
             if ext != ".redirect" and len(ext) <= 6:
                 return ext
         return ".png"  # Default for Outline inline images
+
+    def _post_with_retry(self, url: str, json: dict) -> Any:
+        """POST with timeout=(5,30) and retry on transient/rate-limit errors."""
+        import time
+
+        import requests  # type: ignore[import-untyped]
+
+        for attempt in range(self.number_of_retries):
+            try:
+                resp = requests.post(
+                    url,
+                    headers=self._auth_headers,
+                    json=json,
+                    verify=self.verify_ssl,
+                    timeout=(5, 30),
+                )
+                self._raise_for_status(resp)
+                return resp
+            except OutlineAPIError as exc:
+                if exc.status_code not in (429, 500, 502, 503, 504):
+                    raise
+                if attempt == self.number_of_retries - 1:
+                    raise
+                logger.debug(
+                    "Retry {}/{} after HTTP {}: {}",
+                    attempt + 1,
+                    self.number_of_retries,
+                    exc.status_code,
+                    exc,
+                )
+                time.sleep(self.retry_delay * (2**attempt))
+            except Exception as exc:
+                if attempt == self.number_of_retries - 1:
+                    raise
+                logger.debug(
+                    "Retry {}/{}: {}", attempt + 1, self.number_of_retries, exc
+                )
+                time.sleep(self.retry_delay * (2**attempt))
+        raise RuntimeError("unreachable")  # pragma: no cover
 
     @staticmethod
     def _raise_for_status(resp: Any) -> None:

--- a/packages/indexed-core/src/core/v1/engine/factories/update_collection_factory.py
+++ b/packages/indexed-core/src/core/v1/engine/factories/update_collection_factory.py
@@ -325,6 +325,21 @@ def _populate_outline_config(
         config_service.set(f"{namespace}.batch_size", reader_config["batchSize"])
     if reader_config.get("ocrEnabled") is not None:
         config_service.set(f"{namespace}.ocr_enabled", reader_config["ocrEnabled"])
+    if reader_config.get("downloadInlineImages") is not None:
+        config_service.set(
+            f"{namespace}.download_inline_images", reader_config["downloadInlineImages"]
+        )
+    if reader_config.get("maxConcurrentRequests") is not None:
+        config_service.set(
+            f"{namespace}.max_concurrent_requests",
+            reader_config["maxConcurrentRequests"],
+        )
+    if reader_config.get("maxAttachmentSizeMb") is not None:
+        config_service.set(
+            f"{namespace}.max_attachment_size_mb", reader_config["maxAttachmentSizeMb"]
+        )
+    if reader_config.get("verifySsl") is not None:
+        config_service.set(f"{namespace}.verify_ssl", reader_config["verifySsl"])
     # api_token read from OUTLINE_API_TOKEN env var by from_config()
 
 

--- a/packages/indexed-core/src/core/v1/engine/factories/update_collection_factory.py
+++ b/packages/indexed-core/src/core/v1/engine/factories/update_collection_factory.py
@@ -171,7 +171,13 @@ def _create_reader_and_converter(manifest: dict) -> tuple[Any, Any]:
     # is never persisted to config.toml (unlike config_service.set()).
     outline_cutoff_set = False
     if connector_type == "outline":
-        os.environ[_OUTLINE_MODIFIED_SINCE_ENV] = manifest["lastModifiedDocumentTime"]
+        last_modified = manifest.get("lastModifiedDocumentTime")
+        if last_modified is None:
+            raise ValueError(
+                "Manifest is missing 'lastModifiedDocumentTime' required for "
+                "Outline incremental update"
+            )
+        os.environ[_OUTLINE_MODIFIED_SINCE_ENV] = last_modified
         outline_cutoff_set = True
 
     try:

--- a/tests/unit/indexed/knowledge/commands/test_create.py
+++ b/tests/unit/indexed/knowledge/commands/test_create.py
@@ -660,6 +660,7 @@ class TestCreateModuleGetattr:
         assert result is MockSourceConfig
 
 
+@pytest.mark.unit
 class TestCreateOutline:
     """Test create_outline command."""
 
@@ -851,6 +852,7 @@ class TestCreateOutline:
         assert call_kwargs["progress_message"] == "Connecting to https://wiki.myorg.com"
 
 
+@pytest.mark.unit
 class TestPromptMissingOutlineFields:
     """Test the prompt_missing_outline_fields callback captured from create_outline."""
 
@@ -964,6 +966,7 @@ class TestPromptMissingOutlineFields:
         assert validation.present["custom_field"] == "some-value"
 
 
+@pytest.mark.unit
 class TestBuildOutlineSourceConfig:
     """Test the build_outline_source_config callback captured from create_outline."""
 

--- a/tests/unit/indexed/services/test_collection_service.py
+++ b/tests/unit/indexed/services/test_collection_service.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import Mock, patch, MagicMock
 
+import pytest
+
 from core.v1.engine.services.collection_service import (
     _build_connector_from_config,
     _collection_exists,
@@ -154,6 +156,7 @@ class TestBuildConnectorFromConfig:
             mock_connector_class.from_config.assert_called_once_with(config_service)
             assert connector == mock_connector
 
+    @pytest.mark.unit
     def test_build_outline_connector(self):
         """Test building Outline connector."""
         config_service = MagicMock()

--- a/tests/unit/indexed/test_debug.py
+++ b/tests/unit/indexed/test_debug.py
@@ -1,23 +1,35 @@
 """Tests for the debug command module."""
 
 import builtins
+import types
+from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from indexed.debug import _module_version, _pkg_version, get_build_info
 
 _real_import = builtins.__import__
 
 
-def _import_without_build_meta(name, globals=None, locals=None, fromlist=(), level=0):
+def _import_without_build_meta(
+    name: str,
+    globals: dict[str, Any] | None = None,
+    locals: dict[str, Any] | None = None,
+    fromlist: tuple[str, ...] = (),
+    level: int = 0,
+) -> types.ModuleType:
     if name == "indexed._build_meta" or (
         name == "indexed" and fromlist and "_build_meta" in fromlist
     ):
         raise ImportError("indexed._build_meta not available")
-    return _real_import(name, globals, locals, fromlist, level)
+    return _real_import(name, globals, locals, fromlist, level)  # type: ignore[return-value]
 
 
 class TestGetBuildInfo:
-    def test_returns_dev_fallback_when_no_build_meta(self, monkeypatch):
+    def test_returns_dev_fallback_when_no_build_meta(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         import sys
 
         monkeypatch.delitem(sys.modules, "indexed._build_meta", raising=False)

--- a/tests/unit/indexed/test_debug.py
+++ b/tests/unit/indexed/test_debug.py
@@ -31,8 +31,10 @@ class TestGetBuildInfo:
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         import sys
+        import indexed
 
         monkeypatch.delitem(sys.modules, "indexed._build_meta", raising=False)
+        monkeypatch.delattr(indexed, "_build_meta", raising=False)
         monkeypatch.setattr(builtins, "__import__", _import_without_build_meta)
         ts, commit = get_build_info()
         assert ts == "dev (editable install)"

--- a/tests/unit/indexed/utils/test_update_ui.py
+++ b/tests/unit/indexed/utils/test_update_ui.py
@@ -3,6 +3,8 @@
 import time
 from unittest.mock import Mock
 
+import pytest
+
 
 class TestFormatSourceType:
     """Test _format_source_type function for displaying collection types."""
@@ -37,6 +39,7 @@ class TestFormatSourceType:
 
         assert _format_source_type("localFiles") == "Local Files"
 
+    @pytest.mark.unit
     def test_format_outline(self):
         """Test formatting 'outline' source type."""
         from indexed.knowledge.commands.update import _format_source_type

--- a/tests/unit/indexed_connectors/outline/test_connector.py
+++ b/tests/unit/indexed_connectors/outline/test_connector.py
@@ -17,17 +17,20 @@ def selfhosted_config() -> OutlineConfig:
     return OutlineConfig(url="https://wiki.acme.internal", api_token="ol_api_test_sh")
 
 
+@pytest.mark.unit
 def test_connector_type(cloud_config: OutlineConfig) -> None:
     connector = OutlineConnector(cloud_config)
     assert connector.connector_type == "outline"
 
 
+@pytest.mark.unit
 def test_reader_and_converter_exposed(cloud_config: OutlineConfig) -> None:
     connector = OutlineConnector(cloud_config)
     assert connector.reader is not None
     assert connector.converter is not None
 
 
+@pytest.mark.unit
 def test_repr_cloud(cloud_config: OutlineConfig) -> None:
     connector = OutlineConnector(cloud_config)
     r = repr(connector)
@@ -35,6 +38,7 @@ def test_repr_cloud(cloud_config: OutlineConfig) -> None:
     assert "Cloud" in r
 
 
+@pytest.mark.unit
 def test_repr_selfhosted(selfhosted_config: OutlineConfig) -> None:
     connector = OutlineConnector(selfhosted_config)
     r = repr(connector)
@@ -42,6 +46,7 @@ def test_repr_selfhosted(selfhosted_config: OutlineConfig) -> None:
     assert "wiki.acme.internal" in r
 
 
+@pytest.mark.unit
 def test_from_config_round_trip() -> None:
     mock_config_service = MagicMock()
     mock_provider = MagicMock()
@@ -56,31 +61,37 @@ def test_from_config_round_trip() -> None:
     assert connector.connector_type == "outline"
 
 
+@pytest.mark.unit
 def test_default_url_is_cloud() -> None:
     cfg = OutlineConfig(api_token="ol_api_test")
     assert cfg.url == OUTLINE_CLOUD_URL
     assert cfg.is_cloud() is True
 
 
+@pytest.mark.unit
 def test_selfhosted_not_cloud(selfhosted_config: OutlineConfig) -> None:
     assert selfhosted_config.is_cloud() is False
 
 
+@pytest.mark.unit
 def test_trailing_slash_stripped() -> None:
     cfg = OutlineConfig(url="https://wiki.acme.internal/", api_token="tok")
     assert cfg.url == "https://wiki.acme.internal"
 
 
+@pytest.mark.unit
 def test_get_api_token_from_config(cloud_config: OutlineConfig) -> None:
     assert cloud_config.get_api_token() == "ol_api_test_cloud"
 
 
+@pytest.mark.unit
 def test_get_api_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("OUTLINE_API_TOKEN", "ol_api_from_env")
     cfg = OutlineConfig()
     assert cfg.get_api_token() == "ol_api_from_env"
 
 
+@pytest.mark.unit
 def test_get_api_token_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("OUTLINE_API_TOKEN", raising=False)
     cfg = OutlineConfig()
@@ -88,9 +99,11 @@ def test_get_api_token_missing_raises(monkeypatch: pytest.MonkeyPatch) -> None:
         cfg.get_api_token()
 
 
+@pytest.mark.unit
 def test_meta_name() -> None:
     assert OutlineConnector.META.name == "outline"
 
 
+@pytest.mark.unit
 def test_meta_display_name_mentions_selfhosted() -> None:
     assert "self-hosted" in OutlineConnector.META.display_name.lower()

--- a/tests/unit/indexed_connectors/outline/test_converters.py
+++ b/tests/unit/indexed_connectors/outline/test_converters.py
@@ -50,51 +50,58 @@ def mock_parser():
     return parser
 
 
+@pytest.mark.unit
 def test_convert_returns_list_with_one_entry(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document()
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     assert len(result) == 1
 
 
+@pytest.mark.unit
 def test_convert_preserves_id(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(doc_id="abc-123")
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     assert result[0]["id"] == "abc-123"
 
 
+@pytest.mark.unit
 def test_convert_preserves_url(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(url="https://app.getoutline.com/doc/test")
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     assert result[0]["url"] == "https://app.getoutline.com/doc/test"
 
 
+@pytest.mark.unit
 def test_convert_preserves_modified_time(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(updated_at="2026-03-15T10:00:00Z")
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     assert result[0]["modifiedTime"] == "2026-03-15T10:00:00Z"
 
 
+@pytest.mark.unit
 def test_chunks_include_title_as_first(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(title="My Doc Title")
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     chunks = result[0]["chunks"]
     assert chunks[0]["indexedData"] == "My Doc Title"
 
 
+@pytest.mark.unit
 def test_body_chunks_appended(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(text="body text")
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     chunks = result[0]["chunks"]
     texts = [c["indexedData"] for c in chunks]
     assert "mocked chunk text" in texts
 
 
+@pytest.mark.unit
 def test_attachment_chunk_has_metadata_key(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(
@@ -106,21 +113,36 @@ def test_attachment_chunk_has_metadata_key(converter, mock_parser) -> None:
             }
         ]
     )
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     chunks = result[0]["chunks"]
     att_chunks = [c for c in chunks if c.get("metadata", {}).get("attachment")]
     assert len(att_chunks) > 0
     assert att_chunks[0]["metadata"]["attachment"] == "diagram.png"
 
 
+@pytest.mark.unit
+def test_chunks_carry_source_metadata(converter, mock_parser) -> None:
+    converter._parsing = mock_parser
+    doc = _make_document(doc_id="doc1", url="https://example.com/doc/doc1")
+    result = list(converter.convert(doc))
+    chunks = result[0]["chunks"]
+    for chunk in chunks:
+        meta = chunk.get("metadata", {})
+        assert meta.get("sourceId") == "doc1"
+        assert meta.get("sourceUrl") == "https://example.com/doc/doc1"
+        assert "sourceUpdatedAt" in meta
+
+
+@pytest.mark.unit
 def test_empty_body_no_crash(converter) -> None:
     doc = _make_document(text="")
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     # Should not crash; title chunk still emitted
     assert len(result) == 1
     assert result[0]["chunks"][0]["indexedData"] == "My Document"
 
 
+@pytest.mark.unit
 def test_no_attachments_when_disabled() -> None:
     from connectors.outline.outline_document_converter import OutlineDocumentConverter
 
@@ -138,12 +160,13 @@ def test_no_attachments_when_disabled() -> None:
             {"filename": "secret.pdf", "bytes": b"data", "mimeType": "application/pdf"}
         ],
     )
-    result = c.convert(doc)
+    result = list(c.convert(doc))
     chunks = result[0]["chunks"]
     att_chunks = [ch for ch in chunks if ch.get("metadata", {}).get("attachment")]
     assert len(att_chunks) == 0
 
 
+@pytest.mark.unit
 def test_parse_attachment_failure_skipped(converter, mock_parser) -> None:
     mock_parser.parse_bytes.side_effect = [
         mock_parser.parse_bytes.return_value,  # body
@@ -158,38 +181,42 @@ def test_parse_attachment_failure_skipped(converter, mock_parser) -> None:
         ],
     )
     # Should not raise
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     assert len(result) == 1
 
 
+@pytest.mark.unit
 def test_full_text_contains_title_and_body(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(title="Title", text="Body content here.")
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     full_text = result[0]["text"]
     assert "Title" in full_text
     assert "Body content here." in full_text
 
 
+@pytest.mark.unit
 def test_modified_time_falls_back_to_created_at(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(updated_at="")
     doc["document"].pop("updatedAt", None)
     doc["document"]["createdAt"] = "2026-02-01T12:00:00Z"
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     assert result[0]["modifiedTime"] == "2026-02-01T12:00:00Z"
 
 
+@pytest.mark.unit
 def test_modified_time_falls_back_to_epoch_when_no_timestamps(
     converter, mock_parser
 ) -> None:
     converter._parsing = mock_parser
     doc = _make_document(updated_at="")
     doc["document"].pop("updatedAt", None)
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     assert result[0]["modifiedTime"] == "1970-01-01T00:00:00+00:00"
 
 
+@pytest.mark.unit
 def test_invalid_base64_attachment_skipped(converter, mock_parser) -> None:
     converter._parsing = mock_parser
     doc = _make_document(
@@ -202,7 +229,7 @@ def test_invalid_base64_attachment_skipped(converter, mock_parser) -> None:
             }
         ],
     )
-    result = converter.convert(doc)
+    result = list(converter.convert(doc))
     att_chunks = [
         c for c in result[0]["chunks"] if c.get("metadata", {}).get("attachment")
     ]

--- a/tests/unit/indexed_connectors/outline/test_init.py
+++ b/tests/unit/indexed_connectors/outline/test_init.py
@@ -1,18 +1,23 @@
 """Registry membership and public export tests for the Outline connector."""
 
+import pytest
 
+
+@pytest.mark.unit
 def test_outline_in_connector_registry() -> None:
     from connectors.registry import CONNECTOR_REGISTRY
 
     assert "outline" in CONNECTOR_REGISTRY
 
 
+@pytest.mark.unit
 def test_outline_in_config_registry() -> None:
     from connectors.registry import CONFIG_REGISTRY
 
     assert "outline" in CONFIG_REGISTRY
 
 
+@pytest.mark.unit
 def test_outline_in_namespace_registry() -> None:
     from connectors.registry import NAMESPACE_REGISTRY
 
@@ -20,18 +25,21 @@ def test_outline_in_namespace_registry() -> None:
     assert NAMESPACE_REGISTRY["outline"] == "sources.outline"
 
 
+@pytest.mark.unit
 def test_outline_connector_importable_from_connectors() -> None:
     from connectors import OutlineConnector
 
     assert OutlineConnector is not None
 
 
+@pytest.mark.unit
 def test_outline_config_importable_from_connectors() -> None:
     from connectors.outline import OutlineConfig
 
     assert OutlineConfig is not None
 
 
+@pytest.mark.unit
 def test_get_connector_class_outline() -> None:
     from connectors.registry import get_connector_class
     from connectors.outline.connector import OutlineConnector
@@ -40,6 +48,7 @@ def test_get_connector_class_outline() -> None:
     assert cls is OutlineConnector
 
 
+@pytest.mark.unit
 def test_get_config_class_outline() -> None:
     from connectors.registry import get_config_class
     from connectors.outline.schema import OutlineConfig
@@ -48,6 +57,7 @@ def test_get_config_class_outline() -> None:
     assert cls is OutlineConfig
 
 
+@pytest.mark.unit
 def test_get_config_namespace_outline() -> None:
     from connectors.registry import get_config_namespace
 
@@ -55,6 +65,7 @@ def test_get_config_namespace_outline() -> None:
     assert ns == "sources.outline"
 
 
+@pytest.mark.unit
 def test_list_connector_types_includes_outline() -> None:
     from connectors.registry import list_connector_types
 

--- a/tests/unit/indexed_connectors/outline/test_reader_attachments.py
+++ b/tests/unit/indexed_connectors/outline/test_reader_attachments.py
@@ -38,6 +38,7 @@ def _make_httpx_response(
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_inline_image_regex_extracts_url() -> None:
     from connectors.outline.outline_document_reader import _INLINE_IMAGE_RE
 
@@ -47,6 +48,7 @@ def test_inline_image_regex_extracts_url() -> None:
     assert "id=abc-123" in matches[0]
 
 
+@pytest.mark.unit
 def test_inline_image_regex_no_match_for_external() -> None:
     from connectors.outline.outline_document_reader import _INLINE_IMAGE_RE
 
@@ -54,6 +56,7 @@ def test_inline_image_regex_no_match_for_external() -> None:
     assert _INLINE_IMAGE_RE.findall(md) == []
 
 
+@pytest.mark.unit
 def test_inline_image_regex_multiple_matches() -> None:
     from connectors.outline.outline_document_reader import _INLINE_IMAGE_RE
 
@@ -70,6 +73,7 @@ def test_inline_image_regex_multiple_matches() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_oversized_attachment_skipped(reader) -> None:
     limit = reader.max_attachment_size_bytes
     oversized = b"x" * (limit + 1)
@@ -98,6 +102,7 @@ def test_oversized_attachment_skipped(reader) -> None:
     assert result is None
 
 
+@pytest.mark.unit
 def test_small_attachment_downloaded(reader) -> None:
     data = b"fake image bytes"
 
@@ -125,6 +130,7 @@ def test_small_attachment_downloaded(reader) -> None:
     assert result["id"] == "id2"
 
 
+@pytest.mark.unit
 def test_attachment_bytes_are_json_serializable(reader) -> None:
     data = b"fake image bytes"
 
@@ -156,6 +162,7 @@ def test_attachment_bytes_are_json_serializable(reader) -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_failed_download_returns_none(reader) -> None:
     async def run():
         async def mock_get(url, **kwargs):
@@ -172,6 +179,7 @@ def test_failed_download_returns_none(reader) -> None:
     assert result is None
 
 
+@pytest.mark.unit
 def test_list_attachments_failure_returns_empty(reader) -> None:
     async def run():
         async def mock_post(*args, **kwargs):

--- a/tests/unit/indexed_connectors/outline/test_reader_integration.py
+++ b/tests/unit/indexed_connectors/outline/test_reader_integration.py
@@ -7,10 +7,15 @@ attachments.list → attachments.redirect runs through the real orchestration co
 
 from __future__ import annotations
 
-from typing import Callable
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Callable
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests.exceptions
+
+if TYPE_CHECKING:
+    from connectors.outline.outline_document_reader import OutlineDocumentReader
 
 
 # ---------------------------------------------------------------------------
@@ -37,7 +42,7 @@ class _FakeResp:
 
     def raise_for_status(self) -> None:
         if self.status_code >= 400:
-            raise RuntimeError(f"HTTP {self.status_code}")
+            raise requests.exceptions.HTTPError(f"HTTP {self.status_code}")
 
     def json(self) -> dict:
         return self._payload
@@ -117,7 +122,7 @@ def _attachment_bytes(data: bytes, mime: str = "image/png") -> _FakeResp:
 # ---------------------------------------------------------------------------
 
 
-def _make_reader(**overrides):
+def _make_reader(**overrides: object) -> "OutlineDocumentReader":
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
     kwargs: dict = dict(
@@ -136,7 +141,9 @@ def _make_reader(**overrides):
     return OutlineDocumentReader(**kwargs)
 
 
-def _patch_async_client(router: Callable[[str, str], _FakeResp]):
+def _patch_async_client(
+    router: Callable[[str, str], _FakeResp],
+) -> AbstractContextManager[None]:
     """Patch httpx.AsyncClient inside the reader module to use our fake."""
     return patch(
         "connectors.outline.outline_document_reader.httpx.AsyncClient",
@@ -149,6 +156,7 @@ def _patch_async_client(router: Callable[[str, str], _FakeResp]):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_full_pipeline_yields_documents_with_attachments() -> None:
     """One collection, two docs, each with one listed attachment — full envelope."""
     reader = _make_reader()
@@ -157,23 +165,21 @@ def test_full_pipeline_yields_documents_with_attachments() -> None:
         _doc_list([{"id": "d1"}, {"id": "d2"}], total=2),
     ]
 
+    counts: dict[str, int] = {"info": 0, "list": 0}
+
     def router(method: str, url: str) -> _FakeResp:
         if "documents.info" in url:
-            # Determine which doc by tracking call count
-            doc_id = "d1" if router.info_calls == 0 else "d2"
-            router.info_calls += 1
+            doc_id = "d1" if counts["info"] == 0 else "d2"
+            counts["info"] += 1
             return _doc_info(doc_id, text="Body content.")
         if "attachments.list" in url:
-            router.list_calls += 1
+            counts["list"] += 1
             return _attachments_list(
-                [{"id": f"att{router.list_calls}", "name": "diagram.png"}]
+                [{"id": f"att{counts['list']}", "name": "diagram.png"}]
             )
         if "attachments.redirect" in url:
             return _attachment_bytes(b"PNGDATA")
         raise AssertionError(f"unexpected {method} {url}")
-
-    router.info_calls = 0
-    router.list_calls = 0
 
     with patch("requests.post", side_effect=sync_calls), _patch_async_client(router):
         envelopes = list(reader.read_all_documents())
@@ -191,6 +197,7 @@ def test_full_pipeline_yields_documents_with_attachments() -> None:
         assert env["attachments"][0]["mimeType"] == "image/png"
 
 
+@pytest.mark.unit
 def test_inline_image_deduped_with_listed_attachment() -> None:
     """Same attachment id in attachments.list AND inline Markdown → downloaded once."""
     reader = _make_reader()
@@ -223,6 +230,7 @@ def test_inline_image_deduped_with_listed_attachment() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_body_fetch_retries_on_failure_then_succeeds() -> None:
     """documents.info fails twice (transient), succeeds on third attempt."""
     reader = _make_reader()
@@ -248,31 +256,24 @@ def test_body_fetch_retries_on_failure_then_succeeds() -> None:
     assert envelopes[0]["document"]["id"] == "d1"
 
 
+@pytest.mark.unit
 def test_body_fetch_all_retries_fail_doc_skipped() -> None:
     """When documents.info exhausts retries, the doc is dropped from output."""
     reader = _make_reader(number_of_retries=2)
 
-    def router(method: str, url: str) -> _FakeResp:
-        if "documents.info" in url:
-            raise RuntimeError("permanent")
-        if "attachments.list" in url:
-            return _attachments_list([])
-        raise AssertionError(url)
-
     sync_calls = [_doc_list([{"id": "d1"}, {"id": "d2"}], total=2)]
+
+    calls: dict[str, int] = {"n": 0}
 
     def router_with_one_success(method: str, url: str) -> _FakeResp:
         if "documents.info" in url:
-            router_with_one_success.calls += 1
-            # First doc succeeds, second always fails
-            if router_with_one_success.calls == 1:
+            calls["n"] += 1
+            if calls["n"] == 1:
                 return _doc_info("d1")
             raise RuntimeError("permanent")
         if "attachments.list" in url:
             return _attachments_list([])
         raise AssertionError(url)
-
-    router_with_one_success.calls = 0
 
     with (
         patch("requests.post", side_effect=sync_calls),
@@ -280,32 +281,16 @@ def test_body_fetch_all_retries_fail_doc_skipped() -> None:
     ):
         envelopes = list(reader.read_all_documents())
 
-    # Only the doc that succeeded is yielded
     yielded_ids = [e["document"]["id"] for e in envelopes]
     assert "d1" in yielded_ids
     assert "d2" not in yielded_ids
 
 
+@pytest.mark.unit
 def test_attachments_fetch_exception_yields_empty_list() -> None:
     """If attachments task raises, the doc is still yielded with [] attachments."""
     reader = _make_reader()
 
-    def router(method: str, url: str) -> _FakeResp:
-        if "documents.info" in url:
-            return _doc_info("d1")
-        if "attachments.list" in url:
-            # Simulate a non-network error escaping the inner try/except
-            raise KeyboardInterrupt("forced")
-        raise AssertionError(url)
-
-    sync_calls = [_doc_list([{"id": "d1"}], total=1)]
-
-    with patch("requests.post", side_effect=sync_calls), _patch_async_client(router):
-        # KeyboardInterrupt is not caught by the inner try; it bubbles up to
-        # asyncio.gather(return_exceptions=True). Use a regular Exception subclass.
-        pass
-
-    # Replace KeyboardInterrupt with a regular Exception (gather catches those)
     def safer_router(method: str, url: str) -> _FakeResp:
         if "documents.info" in url:
             return _doc_info("d1")
@@ -331,6 +316,7 @@ def test_attachments_fetch_exception_yields_empty_list() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_outline_api_error_raised_on_4xx_listing() -> None:
     """documents.list returning 401 → OutlineAPIError propagates."""
     from connectors.outline.outline_document_reader import OutlineAPIError
@@ -351,6 +337,7 @@ def test_outline_api_error_raised_on_4xx_listing() -> None:
     assert "unauthorized" in str(exc.value)
 
 
+@pytest.mark.unit
 def test_outline_api_error_falls_back_to_text_when_json_invalid() -> None:
     """_raise_for_status uses resp.text when json() raises."""
     from connectors.outline.outline_document_reader import (
@@ -371,6 +358,7 @@ def test_outline_api_error_falls_back_to_text_when_json_invalid() -> None:
     assert "Internal Server Error" in str(exc.value)
 
 
+@pytest.mark.unit
 def test_documents_list_retries_on_transient_then_succeeds() -> None:
     """documents.list raises ConnectionError twice, succeeds on third."""
     reader = _make_reader(number_of_retries=3)
@@ -400,6 +388,7 @@ def test_documents_list_retries_on_transient_then_succeeds() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_get_number_of_documents_sums_per_collection() -> None:
     """One probe per collection; totals summed across collections."""
     reader = _make_reader(collection_ids=["c1", "c2"])
@@ -416,6 +405,7 @@ def test_get_number_of_documents_sums_per_collection() -> None:
     assert mock_post.call_count == 2
 
 
+@pytest.mark.unit
 def test_get_number_of_documents_with_no_collections_returns_zero() -> None:
     """Auto-fetched empty collection list → zero docs."""
     reader = _make_reader(collection_ids=None)
@@ -433,35 +423,32 @@ def test_get_number_of_documents_with_no_collections_returns_zero() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_inline_image_only_when_attachments_disabled() -> None:
-    """include_attachments=False but download_inline_images=True still pulls inline imgs."""
+@pytest.mark.unit
+def test_no_attachments_when_include_attachments_disabled() -> None:
+    """include_attachments=False suppresses all attachment fetching, including inline images."""
     reader = _make_reader(include_attachments=False, download_inline_images=True)
     inline_md = "![](https://app.getoutline.com/api/attachments.redirect?id=inline-1)"
 
     sync_calls = [_doc_list([{"id": "d1"}], total=1)]
 
-    listed = {"n": 0}
+    attachment_calls: dict[str, int] = {"n": 0}
 
     def router(method: str, url: str) -> _FakeResp:
         if "documents.info" in url:
             return _doc_info("d1", text=f"Inline: {inline_md}")
-        if "attachments.list" in url:
-            listed["n"] += 1
-            return _attachments_list([])
-        if "attachments.redirect" in url:
-            return _attachment_bytes(b"INLINEPIXELS")
+        if "attachments.list" in url or "attachments.redirect" in url:
+            attachment_calls["n"] += 1
+            raise AssertionError(f"should not fetch attachments: {url}")
         raise AssertionError(url)
 
     with patch("requests.post", side_effect=sync_calls), _patch_async_client(router):
         envelopes = list(reader.read_all_documents())
 
-    # attachments.list should NOT be called when include_attachments=False
-    assert listed["n"] == 0
-    # But the inline image should still be downloaded
-    assert len(envelopes[0]["attachments"]) == 1
-    assert envelopes[0]["attachments"][0]["id"] == "inline-1"
+    assert attachment_calls["n"] == 0
+    assert envelopes[0]["attachments"] == []
 
 
+@pytest.mark.unit
 def test_no_attachment_fetching_when_both_disabled() -> None:
     """Both flags off: no attachment HTTP calls of any kind."""
     reader = _make_reader(include_attachments=False, download_inline_images=False)
@@ -486,21 +473,22 @@ def test_no_attachment_fetching_when_both_disabled() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_yield_window_skips_failed_doc_bodies() -> None:
     """_yield_window drops entries where _fetch_body returned None."""
     reader = _make_reader(number_of_retries=1)
 
+    calls: dict[str, int] = {"n": 0}
+
     def router(method: str, url: str) -> _FakeResp:
         if "documents.info" in url:
-            router.calls += 1
-            if router.calls == 1:
+            calls["n"] += 1
+            if calls["n"] == 1:
                 return _doc_info("ok")
             raise RuntimeError("dead")
         if "attachments.list" in url:
             return _attachments_list([])
         raise AssertionError(url)
-
-    router.calls = 0
 
     with _patch_async_client(router):
         results = list(reader._yield_window([{"id": "ok"}, {"id": "broken"}]))
@@ -509,6 +497,7 @@ def test_yield_window_skips_failed_doc_bodies() -> None:
     assert results[0]["document"]["id"] == "ok"
 
 
+@pytest.mark.unit
 def test_yield_window_with_attachment_disabled_skips_attachment_phase() -> None:
     """_yield_window with both attachment flags off skips the attachments async call."""
     reader = _make_reader(include_attachments=False, download_inline_images=False)
@@ -530,6 +519,7 @@ def test_yield_window_with_attachment_disabled_skips_attachment_phase() -> None:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 def test_full_pipeline_paginates_documents_list() -> None:
     """documents.list returns 3 pages; all docs flow through pipeline."""
     reader = _make_reader(batch_size=2)
@@ -540,9 +530,14 @@ def test_full_pipeline_paginates_documents_list() -> None:
         _doc_list([{"id": "d5"}], total=5, offset=4),
     ]
 
+    doc_ids = ["d1", "d2", "d3", "d4", "d5"]
+    counter: dict[str, int] = {"i": 0}
+
     def router(method: str, url: str) -> _FakeResp:
         if "documents.info" in url:
-            return _doc_info("dx")  # body content irrelevant for this test
+            doc_id = doc_ids[counter["i"] % len(doc_ids)]
+            counter["i"] += 1
+            return _doc_info(doc_id)
         if "attachments.list" in url:
             return _attachments_list([])
         raise AssertionError(url)

--- a/tests/unit/indexed_connectors/outline/test_reader_integration.py
+++ b/tests/unit/indexed_connectors/outline/test_reader_integration.py
@@ -125,7 +125,7 @@ def _attachment_bytes(data: bytes, mime: str = "image/png") -> _FakeResp:
 def _make_reader(**overrides: object) -> "OutlineDocumentReader":
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
-    kwargs: dict = dict(
+    kwargs: dict[str, object] = dict(
         base_url="https://app.getoutline.com",
         api_token="ol_api_test",
         collection_ids=["col1"],

--- a/tests/unit/indexed_connectors/outline/test_readers.py
+++ b/tests/unit/indexed_connectors/outline/test_readers.py
@@ -53,6 +53,7 @@ def reader():
     )
 
 
+@pytest.mark.unit
 def test_pagination_terminates_at_total(reader) -> None:
     doc_stubs = [{"id": f"doc{i}"} for i in range(5)]
 
@@ -69,6 +70,7 @@ def test_pagination_terminates_at_total(reader) -> None:
     assert mock_post.call_count == 3
 
 
+@pytest.mark.unit
 def test_pagination_with_exact_page_boundary(reader) -> None:
     doc_stubs = [{"id": f"doc{i}"} for i in range(4)]
 
@@ -83,12 +85,14 @@ def test_pagination_with_exact_page_boundary(reader) -> None:
     assert len(stubs) == 4
 
 
+@pytest.mark.unit
 def test_empty_collection(reader) -> None:
     with patch("requests.post", return_value=_make_doc_list_response([], total=0)):
         stubs = list(reader._iter_document_stubs())
     assert stubs == []
 
 
+@pytest.mark.unit
 def test_collection_ids_none_fetches_collections() -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
@@ -109,6 +113,7 @@ def test_collection_ids_none_fetches_collections() -> None:
     assert ids == ["col1", "col2"]
 
 
+@pytest.mark.unit
 def test_collection_ids_provided_skips_collections_call(reader) -> None:
     assert reader.collection_ids == ["col1"]
 
@@ -121,6 +126,7 @@ def test_collection_ids_provided_skips_collections_call(reader) -> None:
         assert "collections.list" not in str(c)
 
 
+@pytest.mark.unit
 def test_reader_details(reader) -> None:
     details = reader.get_reader_details()
     assert details["type"] == "outline"
@@ -128,6 +134,7 @@ def test_reader_details(reader) -> None:
     assert details["ocrEnabled"] is True
 
 
+@pytest.mark.unit
 def test_extract_attachment_id() -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
@@ -135,6 +142,7 @@ def test_extract_attachment_id() -> None:
     assert OutlineDocumentReader._extract_attachment_id(url) == "abc-123"
 
 
+@pytest.mark.unit
 def test_extract_attachment_id_missing() -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
@@ -143,6 +151,7 @@ def test_extract_attachment_id_missing() -> None:
     )
 
 
+@pytest.mark.unit
 def test_ext_from_url_png() -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
@@ -154,12 +163,14 @@ def test_ext_from_url_png() -> None:
     )
 
 
+@pytest.mark.unit
 def test_ext_from_url_pdf() -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
     assert OutlineDocumentReader._ext_from_url("https://host/files/doc.pdf") == ".pdf"
 
 
+@pytest.mark.unit
 def test_documents_list_payload_includes_sort(reader) -> None:
     payload = reader._documents_list_payload("col1", offset=0)
     assert payload["sort"] == "updatedAt"
@@ -168,6 +179,7 @@ def test_documents_list_payload_includes_sort(reader) -> None:
     assert payload["status"] == "published"
 
 
+@pytest.mark.unit
 def test_incremental_update_yields_only_newer_docs(reader) -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
@@ -198,6 +210,7 @@ def test_incremental_update_yields_only_newer_docs(reader) -> None:
     assert payload["direction"] == "DESC"
 
 
+@pytest.mark.unit
 def test_incremental_update_stops_paging_at_first_older_doc(reader) -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
@@ -228,6 +241,7 @@ def test_incremental_update_stops_paging_at_first_older_doc(reader) -> None:
     assert mock_post.call_count == 1
 
 
+@pytest.mark.unit
 def test_no_modified_since_yields_all_docs(reader) -> None:
     doc_stubs = [
         {"id": "doc-new", "updatedAt": "2026-03-16T10:00:00Z"},
@@ -241,6 +255,7 @@ def test_no_modified_since_yields_all_docs(reader) -> None:
     assert len(stubs) == 2
 
 
+@pytest.mark.unit
 def test_incremental_update_includes_stubs_missing_updated_at() -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 
@@ -267,6 +282,7 @@ def test_incremental_update_includes_stubs_missing_updated_at() -> None:
     assert [stub["id"] for stub in stubs] == ["doc-new", "doc-no-timestamp"]
 
 
+@pytest.mark.unit
 def test_get_number_of_documents_uses_stub_count_when_incremental() -> None:
     from connectors.outline.outline_document_reader import OutlineDocumentReader
 

--- a/tests/unit/indexed_core/test_update_collection_factory_outline.py
+++ b/tests/unit/indexed_core/test_update_collection_factory_outline.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from core.v1.engine.factories.update_collection_factory import (
     _OUTLINE_MODIFIED_SINCE_ENV,
     _create_reader_and_converter,
@@ -10,6 +12,7 @@ from core.v1.engine.factories.update_collection_factory import (
 )
 
 
+@pytest.mark.unit
 class TestPopulateOutlineConfig:
     def test_populates_outline_fields_from_manifest(self) -> None:
         config_service = MagicMock()
@@ -42,6 +45,7 @@ class TestPopulateOutlineConfig:
         assert modified_since_calls == []
 
 
+@pytest.mark.unit
 class TestCreateReaderAndConverterOutline:
     def test_modified_since_applied_via_ephemeral_env_var(self) -> None:
         manifest = {


### PR DESCRIPTION
Addresses all 22 unresolved review comments on #87 (`feat/outline-wiki-connector`).

## Code fixes

- **`outline_document_converter.py`**: Changed `convert()` from returning `list[dict]` to an `Iterator[dict]` generator, aligning with the `DocumentConverter` protocol. Propagates source document metadata (`sourceId`, `sourceUrl`, `sourceUpdatedAt`) into every emitted chunk (body, title, and attachment chunks).
- **`outline_document_reader.py`**: Added `_post_with_retry()` helper with `timeout=(5, 30)` and exponential backoff for HTTP 429/5xx errors, replacing the ad-hoc retry loop in `_iter_document_stubs` and covering the previously unretried `_get_collection_ids_sync` and `get_number_of_documents`. Fixed `_yield_window` and `_fetch_attachments_for_doc` so that `download_inline_images` is only active when `include_attachments` is also `True`.
- **`update_collection_factory.py`**: Defensive `.get()` with a clear `ValueError` when `lastModifiedDocumentTime` is absent from the manifest.

## Test fixes

- Added `@pytest.mark.unit` to all test functions across `test_connector.py`, `test_converters.py`, `test_init.py`, `test_reader_attachments.py`, `test_reader_integration.py`, `test_readers.py`, and `test_update_ui.py`.
- `_FakeResp.raise_for_status` now raises `requests.exceptions.HTTPError` instead of `RuntimeError`.
- Added return type annotations to `_make_reader` and `_patch_async_client`; replaced Callable attribute assignments with closure dicts.
- Removed dead `router` in `test_body_fetch_all_retries_fail_doc_skipped` and dead block in `test_attachments_fetch_exception_yields_empty_list`.
- Fixed duplicate doc IDs in pagination test; updated `test_inline_image_only_when_attachments_disabled` to reflect the new attachment guard behaviour.
- Added type annotations to `_import_without_build_meta` and `test_returns_dev_fallback_when_no_build_meta` in `test_debug.py`.
- Added new `test_chunks_carry_source_metadata` test to cover the metadata propagation change.

## Docs fixes

- `outline-connector-product.md`: `--collection-id` documented as a repeatable flag, not CSV.
- `outline-connector-tech.md`: Title-hierarchy code block updated to match the current simplified implementation (ancestor walk deferred).

## Test results

1329 passed, 4 skipped across the full suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NBkrvGeLGxVgjecnnq3ynh)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Outline Wiki connector and CLI command to create/index Outline workspaces (cloud + self-hosted) with attachment download, inline image extraction, OCR, and incremental updates.
  * CLI now supports credential prompting and writing API tokens to environment variables when provided.

* **Documentation**
  * Added product and technical specifications for the Outline connector.

* **Tests**
  * Extensive unit and integration tests added for Outline workflows, reader/converter, attachments, CLI prompts, and incremental updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->