### PR TITLE
fix(build): improve release action and auto-attachements of build wheels 

### DIFF
--- a/.github/workflows/python-release-ci.yml
+++ b/.github/workflows/python-release-ci.yml
@@ -79,7 +79,7 @@ jobs:
       # Default packages-dir: dist/ — no override needed.
 
     - name: Attach wheel to GitHub Release
-      if: github.event_name == 'release'
+      if: always() && github.event_name == 'release'
       uses: softprops/action-gh-release@v2
       with:
         files: dist/*

--- a/.github/workflows/python-release-ci.yml
+++ b/.github/workflows/python-release-ci.yml
@@ -38,6 +38,11 @@ jobs:
     - name: Install dependencies
       run: uv sync
 
+    - name: Sync version with release tag
+      env:
+        REF_NAME: ${{ github.ref_name }}
+      run: uv run python tools/sync_version.py "$REF_NAME"
+
     - name: Build distributable wheel
       run: HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
 

--- a/tests/unit/tools/test_sync_version.py
+++ b/tests/unit/tools/test_sync_version.py
@@ -1,0 +1,78 @@
+"""Tests for tools/sync_version.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_SYNC_VERSION_PATH = _REPO_ROOT / "tools" / "sync_version.py"
+
+
+def _load_sync_version():
+    spec = importlib.util.spec_from_file_location("sync_version", _SYNC_VERSION_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_version"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sync_version = _load_sync_version()
+
+
+@pytest.mark.parametrize(
+    ("raw_tag", "expected"),
+    [
+        ("v1.2.3", "1.2.3"),
+        ("1.2.3", "1.2.3"),
+        ("main", None),
+        ("vvv1.0.0", None),
+        ("v1.0.0-beta", None),
+    ],
+)
+def test_parse_version(raw_tag: str, expected: str | None) -> None:
+    assert sync_version.parse_version(raw_tag) == expected
+
+
+def test_sync_version_updates_pyproject(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('version = "0.0.1"\n', encoding="utf-8")
+
+    changed = sync_version.sync_version("v0.2.0", pyproject=pyproject)
+
+    assert changed is True
+    assert pyproject.read_text(encoding="utf-8") == 'version = "0.2.0"\n'
+
+
+def test_sync_version_noop_when_already_current(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('version = "1.0.0"\n', encoding="utf-8")
+
+    changed = sync_version.sync_version("v1.0.0", pyproject=pyproject)
+
+    assert changed is False
+    assert pyproject.read_text(encoding="utf-8") == 'version = "1.0.0"\n'
+
+
+def test_sync_version_skips_non_semver(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('version = "0.0.1"\n', encoding="utf-8")
+
+    changed = sync_version.sync_version("main", pyproject=pyproject)
+
+    assert changed is False
+    assert pyproject.read_text(encoding="utf-8") == 'version = "0.0.1"\n'
+
+
+def test_sync_version_exits_when_version_field_missing(tmp_path: Path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('name = "indexed-sh"\n', encoding="utf-8")
+
+    with pytest.raises(SystemExit) as exc_info:
+        sync_version.sync_version("v1.0.0", pyproject=pyproject)
+
+    assert exc_info.value.code == 1

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+# Sync apps/indexed/pyproject.toml version with a release tag.
+#
+# Usage:
+#   uv run python tools/sync_version.py <tag>
+#
+# The tag may include or omit the 'v' prefix (e.g. 'v0.1.0' or '0.1.0').
+# If the tag is not a valid semver string the script exits successfully with
+# a warning so that workflow_dispatch runs on branch refs are not blocked.
+
+import re
+import sys
+from pathlib import Path
+
+PYPROJECT = Path("apps/indexed/pyproject.toml")
+VERSION_RE = re.compile(r'^(version\s*=\s*")[^"]*(")', re.MULTILINE)
+SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: sync_version.py <tag>", file=sys.stderr)
+        sys.exit(1)
+
+    raw_tag = sys.argv[1]
+    version = raw_tag.lstrip("v")
+
+    if not SEMVER_RE.match(version):
+        print(f"[sync_version] '{raw_tag}' is not a semver tag — skipping.")
+        return
+
+    content = PYPROJECT.read_text(encoding="utf-8")
+    match = VERSION_RE.search(content)
+    if not match:
+        print(
+            f"[sync_version] Could not find version field in {PYPROJECT}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    current = match.group(0).split('"')[1]
+    if current == version:
+        print(f"[sync_version] Version already {version} — no change needed.")
+        return
+
+    updated = VERSION_RE.sub(rf"\g<1>{version}\g<2>", content, count=1)
+    PYPROJECT.write_text(updated, encoding="utf-8")
+    print(f"[sync_version] Updated version: {current} → {version}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/sync_version.py
+++ b/tools/sync_version.py
@@ -12,28 +12,31 @@ import re
 import sys
 from pathlib import Path
 
-PYPROJECT = Path("apps/indexed/pyproject.toml")
-VERSION_RE = re.compile(r'^(version\s*=\s*")[^"]*(")', re.MULTILINE)
-SEMVER_RE = re.compile(r"^\d+\.\d+\.\d+$")
+PYPROJECT: Path = Path("apps/indexed/pyproject.toml")
+VERSION_RE: re.Pattern[str] = re.compile(r'^(version\s*=\s*")[^"]*(")', re.MULTILINE)
+SEMVER_RE: re.Pattern[str] = re.compile(r"^\d+\.\d+\.\d+$")
 
 
-def main() -> None:
-    if len(sys.argv) != 2:
-        print("Usage: sync_version.py <tag>", file=sys.stderr)
-        sys.exit(1)
-
-    raw_tag = sys.argv[1]
-    version = raw_tag.lstrip("v")
-
+def parse_version(raw_tag: str) -> str | None:
+    """Return normalized semver from a tag, or None if not valid."""
+    version = raw_tag[1:] if raw_tag.startswith("v") else raw_tag
     if not SEMVER_RE.match(version):
-        print(f"[sync_version] '{raw_tag}' is not a semver tag — skipping.")
-        return
+        return None
+    return version
 
-    content = PYPROJECT.read_text(encoding="utf-8")
+
+def sync_version(raw_tag: str, pyproject: Path = PYPROJECT) -> bool:
+    """Update pyproject version from tag. Returns True if file was changed."""
+    version = parse_version(raw_tag)
+    if version is None:
+        print(f"[sync_version] '{raw_tag}' is not a semver tag — skipping.")
+        return False
+
+    content = pyproject.read_text(encoding="utf-8")
     match = VERSION_RE.search(content)
     if not match:
         print(
-            f"[sync_version] Could not find version field in {PYPROJECT}",
+            f"[sync_version] Could not find version field in {pyproject}",
             file=sys.stderr,
         )
         sys.exit(1)
@@ -41,11 +44,20 @@ def main() -> None:
     current = match.group(0).split('"')[1]
     if current == version:
         print(f"[sync_version] Version already {version} — no change needed.")
-        return
+        return False
 
     updated = VERSION_RE.sub(rf"\g<1>{version}\g<2>", content, count=1)
-    PYPROJECT.write_text(updated, encoding="utf-8")
+    pyproject.write_text(updated, encoding="utf-8")
     print(f"[sync_version] Updated version: {current} → {version}")
+    return True
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: sync_version.py <tag>", file=sys.stderr)
+        sys.exit(1)
+
+    sync_version(sys.argv[1])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Automated synchronization of the project version with GitHub release tags before building/validating release artifacts, keeping release metadata consistent.
  * Improved CI/CD publishing by adjusting the wheel-to-release attachment condition to behave correctly across release events.
* **Tests**
  * Added unit tests covering version parsing and pyproject version syncing, including no-op behavior and error handling when version metadata is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->