### PR TITLE
fix(build): disable una-build in dev sync

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -39,7 +39,7 @@ jobs:
         uv run pytest tests/system/ -q --tb=short
 
     - name: Build Distributable Wheel (apps/indexed with bundled packages)
-      run: uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
+      run: HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
 
     - name: Validate wheel with PyPI's archive validator
       run: uv run python tools/validate_wheel.py dist/*.whl

--- a/.github/workflows/python-release-ci.yml
+++ b/.github/workflows/python-release-ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: uv sync
 
     - name: Build distributable wheel
-      run: uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
+      run: HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
 
     - name: Validate wheel with PyPI's archive validator
       # Same checks PyPI's warehouse runs on upload. Failing here means PyPI

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
 
       - id: build-check
         name: build wheel (verify buildable)
-        entry: uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
+        entry: HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
         language: system
         stages: [pre-push]
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
 
       - id: build-check
         name: build wheel (verify buildable)
-        entry: HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
+        entry: bash -c 'HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed'
         language: system
         stages: [pre-push]
         pass_filenames: false

--- a/.spec/tech.md
+++ b/.spec/tech.md
@@ -168,7 +168,8 @@ uv run pytest -q --cov=src --cov-report=html
 `una` bundles all workspace packages into a single wheel.
 
 ```bash
-uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
+# Build wheel (HATCH_BUILD_HOOKS_ENABLE=1 required to bundle workspace packages)
+HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
 # → dist/indexed-0.1.0-py3-none-any.whl  (indexed + core + connectors + parsing + config + utils)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,8 +206,8 @@ uv run indexed-mcp run            # Stdio mode (Claude Desktop)
 uv run indexed-mcp run --log-level DEBUG
 uv run indexed-mcp run --transport http --port 8000
 
-# Building
-uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
+# Building (release wheel — bundles workspace packages via una-build)
+HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
 ```
 
 ### Git Commit Standards
@@ -651,7 +651,7 @@ def get_embedder():
 
 **Build failures:**
 - Build from PROJECT ROOT: `cd /path/to/indexed`
-- Use correct command: `uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed`
+- Use correct command: `HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed`
 - Check for missing dependencies: `uv sync --all-groups`
 
 ## Quick Reference

--- a/apps/indexed/README.md
+++ b/apps/indexed/README.md
@@ -61,8 +61,8 @@ uv sync --all-groups
 # Install production dependencies only
 uv sync
 
-# Build a standalone distributable wheel
-uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
+# Build a standalone distributable wheel (bundles workspace packages via una-build)
+HATCH_BUILD_HOOKS_ENABLE=1 uvx --from build pyproject-build --installer=uv --outdir=dist --wheel apps/indexed
 ```
 
 ## CLI Usage

--- a/apps/indexed/pyproject.toml
+++ b/apps/indexed/pyproject.toml
@@ -60,6 +60,7 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [tool.hatch.build.hooks.una-build]
+enable-by-default = false
 
 [tool.hatch.build.hooks.custom]
 

--- a/packages/indexed-config/pyproject.toml
+++ b/packages/indexed-config/pyproject.toml
@@ -26,6 +26,7 @@ dev = [
 allow-direct-references = true
 
 [tool.hatch.build.hooks.una-build]
+enable-by-default = false
 
 [tool.hatch.metadata.hooks.una-meta]
 

--- a/packages/indexed-connectors/pyproject.toml
+++ b/packages/indexed-connectors/pyproject.toml
@@ -33,6 +33,7 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [tool.hatch.build.hooks.una-build]
+enable-by-default = false
 
 [tool.hatch.metadata.hooks.una-meta]
 

--- a/packages/indexed-core/pyproject.toml
+++ b/packages/indexed-core/pyproject.toml
@@ -29,6 +29,7 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [tool.hatch.build.hooks.una-build]
+enable-by-default = false
 
 [tool.hatch.metadata.hooks.una-meta]
 

--- a/packages/indexed-parsing/pyproject.toml
+++ b/packages/indexed-parsing/pyproject.toml
@@ -33,6 +33,7 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [tool.hatch.build.hooks.una-build]
+enable-by-default = false
 
 [tool.hatch.metadata.hooks.una-meta]
 

--- a/packages/utils/pyproject.toml
+++ b/packages/utils/pyproject.toml
@@ -19,6 +19,7 @@ build-backend = "hatchling.build"
 allow-direct-references = true
 
 [tool.hatch.build.hooks.una-build]
+enable-by-default = false
 
 [tool.hatch.metadata.hooks.una-meta]
 


### PR DESCRIPTION
## Summary
- Disable `una-build` hook during editable dev installs (`enable-by-default = false`) so library source edits are live without reinstall
- Enable bundling only for release wheels via `HATCH_BUILD_HOOKS_ENABLE=1` in CI, pre-push, and docs
- Fix pre-push `build-check` hook to pass env var via `bash -c` (pre-commit `language: system` does not support inline env prefixes)

## Problem
During `uv sync`, `hatch-una`'s `una-build` hook copied physical snapshots of workspace packages into `site-packages/`, shadowing editable `.pth` source. Adding new subpackages (e.g. `core.v2`) required reinstalling the app to take effect.

## Test plan
- [x] `uv sync --all-groups --reinstall` — no bundled `core/` dirs in site-packages
- [x] Imports resolve to live source under `packages/*/src`
- [x] `uv run indexed inspect` works
- [x] Release wheel build with `HATCH_BUILD_HOOKS_ENABLE=1` bundles workspace packages
- [x] `validate_wheel.py` passes
- [x] Pre-push `build-check` hook passes


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build configuration and tooling settings across CI workflows and development environments to ensure consistent wheel generation
  * Adjusted build hook default behavior across packages

* **Documentation**
  * Updated build instructions and guides to reflect current requirements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->