### PR TITLE
fix(connectors): migrate Jira Cloud search API

### DIFF
--- a/packages/indexed-connectors/src/connectors/jira/async_jira_cloud_reader.py
+++ b/packages/indexed-connectors/src/connectors/jira/async_jira_cloud_reader.py
@@ -80,7 +80,7 @@ class AsyncJiraCloudDocumentReader:
         credentials = b64encode(f"{email}:{api_token}".encode()).decode()
         return f"Basic {credentials}"
 
-    def read_all_documents(self):
+    def read_all_documents(self) -> list[dict[str, Any]]:
         """Read all documents: sequential JQL search, then optional attachments."""
         issues = self._read_issues_sync()
         if not self.include_attachments:
@@ -91,7 +91,8 @@ class AsyncJiraCloudDocumentReader:
         """Get approximate count of documents matching the query."""
         return self._get_approximate_count()
 
-    def get_reader_details(self) -> dict:
+    def get_reader_details(self) -> dict[str, Any]:
+        """Return reader configuration metadata for diagnostics."""
         return {
             "type": "jiraCloud",
             "baseUrl": self.base_url,
@@ -100,7 +101,7 @@ class AsyncJiraCloudDocumentReader:
             "fields": self.fields,
         }
 
-    def _read_issues_sync(self) -> list[dict]:
+    def _read_issues_sync(self) -> list[dict[str, Any]]:
         """Fetch all issues via sequential nextPageToken pagination."""
         issues: list[dict] = []
         next_token: str | None = None
@@ -135,7 +136,7 @@ class AsyncJiraCloudDocumentReader:
         )
         return int(result.get("count", 0))
 
-    def _post_with_retry(self, url: str, body: dict) -> dict:
+    def _post_with_retry(self, url: str, body: dict[str, Any]) -> dict[str, Any]:
         """POST with retry on transient/rate-limit errors."""
         for attempt in range(self.number_of_retries):
             try:
@@ -192,7 +193,9 @@ class AsyncJiraCloudDocumentReader:
             url=str(response.url),
         )
 
-    async def _enrich_with_attachments(self, issues: list) -> list:
+    async def _enrich_with_attachments(
+        self, issues: list[dict[str, Any]]
+    ) -> list[dict[str, Any]]:
         """Download attachment bytes for all issues concurrently."""
         semaphore = asyncio.Semaphore(self.max_concurrent_requests)
 

--- a/packages/indexed-connectors/src/connectors/jira/async_jira_cloud_reader.py
+++ b/packages/indexed-connectors/src/connectors/jira/async_jira_cloud_reader.py
@@ -103,7 +103,7 @@ class AsyncJiraCloudDocumentReader:
 
     def _read_issues_sync(self) -> list[dict[str, Any]]:
         """Fetch all issues via sequential nextPageToken pagination."""
-        issues: list[dict] = []
+        issues: list[dict[str, Any]] = []
         next_token: str | None = None
 
         while True:
@@ -208,7 +208,7 @@ class AsyncJiraCloudDocumentReader:
         ) as client:
             for issue in issues:
                 att_meta = issue.get("fields", {}).get("attachment", [])
-                downloaded: list[dict] = []
+                downloaded: list[dict[str, Any]] = []
                 for att in att_meta:
                     size = att.get("size", 0)
                     if size > self.max_attachment_size_bytes:

--- a/packages/indexed-connectors/src/connectors/jira/async_jira_cloud_reader.py
+++ b/packages/indexed-connectors/src/connectors/jira/async_jira_cloud_reader.py
@@ -1,21 +1,34 @@
 """Async Jira Cloud document reader using httpx for concurrent requests.
 
-Fetches the issue list via JQL (sequential, paginated), then fetches
-individual issue details concurrently for faster indexing.
+Sequential JQL search via Enhanced JQL API (cursor pagination), then async
+concurrent attachment downloads when enabled.
 """
 
 import asyncio
+import time
 from base64 import b64encode
+from typing import Any
 
 import httpx
+import requests
 from loguru import logger
 
 
-class AsyncJiraCloudDocumentReader:
-    """Jira Cloud reader that uses async HTTP for concurrent issue fetching.
+class JiraCloudAPIError(Exception):
+    """Raised when the Jira Cloud API returns an error response."""
 
-    The initial JQL search is paginated sequentially, but individual issue
-    detail fetching can be parallelized when fetching additional fields.
+    def __init__(self, status_code: int, message: str, url: str) -> None:
+        self.status_code = status_code
+        self.message = message
+        self.url = url
+        super().__init__(f"Jira Cloud API error {status_code} at {url}: {message}")
+
+
+class AsyncJiraCloudDocumentReader:
+    """Jira Cloud reader that uses sequential search and async attachment fetching.
+
+    Issue listing uses the Enhanced JQL API with nextPageToken pagination.
+    Attachment downloads run concurrently via httpx when enabled.
     """
 
     def __init__(
@@ -56,6 +69,11 @@ class AsyncJiraCloudDocumentReader:
             else "summary,description,comment,updated"
         )
         self._auth_header = self._build_auth_header(email, api_token)
+        self._json_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "Authorization": self._auth_header,
+        }
 
     @staticmethod
     def _build_auth_header(email: str, api_token: str) -> str:
@@ -63,31 +81,15 @@ class AsyncJiraCloudDocumentReader:
         return f"Basic {credentials}"
 
     def read_all_documents(self):
-        """Read all documents using async batch fetching."""
-        issues = asyncio.run(self._read_all_async())
+        """Read all documents: sequential JQL search, then optional attachments."""
+        issues = self._read_issues_sync()
         if not self.include_attachments:
             return issues
         return asyncio.run(self._enrich_with_attachments(issues))
 
     def get_number_of_documents(self) -> int:
-        """Get total count of documents matching the query."""
-        import requests
-
-        response = requests.get(
-            url=f"{self.base_url}/rest/api/3/search",
-            headers={
-                "Accept": "application/json",
-                "Authorization": self._auth_header,
-            },
-            params={
-                "jql": self.query,
-                "fields": self.fields,
-                "startAt": 0,
-                "maxResults": 1,
-            },
-        )
-        response.raise_for_status()
-        return response.json().get("total", 0)
+        """Get approximate count of documents matching the query."""
+        return self._get_approximate_count()
 
     def get_reader_details(self) -> dict:
         return {
@@ -98,97 +100,97 @@ class AsyncJiraCloudDocumentReader:
             "fields": self.fields,
         }
 
-    async def _read_all_async(self) -> list:
-        """Fetch all issues using concurrent batch requests."""
-        semaphore = asyncio.Semaphore(self.max_concurrent_requests)
+    def _read_issues_sync(self) -> list[dict]:
+        """Fetch all issues via sequential nextPageToken pagination."""
+        issues: list[dict] = []
+        next_token: str | None = None
 
-        async with httpx.AsyncClient(
-            timeout=30.0,
-            limits=httpx.Limits(
-                max_connections=self.max_concurrent_requests,
-                max_keepalive_connections=5,
-            ),
-        ) as client:
-            # Get total count first
-            total = await self._get_total(client)
-            if total == 0:
-                return []
-
-            # Create tasks for all batches
-            batch_offsets = list(range(0, total, self.batch_size))
-            tasks = [
-                self._fetch_batch(client, semaphore, offset) for offset in batch_offsets
-            ]
-
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-
-        all_issues = []
-        skipped = 0
-        for i, result in enumerate(results):
-            if isinstance(result, Exception):
-                logger.warning(
-                    f"Failed to fetch batch at offset {batch_offsets[i]}: {result}"
-                )
-                skipped += 1
-                if skipped > self.max_skipped_items_in_row:
-                    raise result
-            else:
-                all_issues.extend(result)
-
-        return all_issues
-
-    async def _get_total(self, client: httpx.AsyncClient) -> int:
-        """Get total issue count for the JQL query."""
-        response = await client.get(
-            f"{self.base_url}/rest/api/3/search",
-            headers={
-                "Accept": "application/json",
-                "Authorization": self._auth_header,
-            },
-            params={
+        while True:
+            body: dict[str, Any] = {
                 "jql": self.query,
-                "fields": self.fields,
-                "startAt": 0,
-                "maxResults": 1,
-            },
-        )
-        response.raise_for_status()
-        return response.json().get("total", 0)
+                "fields": self.fields.split(","),
+                "maxResults": self.batch_size,
+            }
+            if next_token:
+                body["nextPageToken"] = next_token
 
-    async def _fetch_batch(
-        self,
-        client: httpx.AsyncClient,
-        semaphore: asyncio.Semaphore,
-        offset: int,
-    ) -> list:
-        """Fetch a batch of issues at the given offset."""
-        async with semaphore:
-            for attempt in range(self.number_of_retries):
-                try:
-                    response = await client.get(
-                        f"{self.base_url}/rest/api/3/search",
-                        headers={
-                            "Accept": "application/json",
-                            "Authorization": self._auth_header,
-                        },
-                        params={
-                            "jql": self.query,
-                            "fields": self.fields,
-                            "startAt": offset,
-                            "maxResults": self.batch_size,
-                        },
-                    )
-                    response.raise_for_status()
-                    data = response.json()
-                    return data.get("issues", [])
-                except Exception as e:
-                    if attempt == self.number_of_retries - 1:
-                        raise
-                    logger.debug(
-                        f"Retry {attempt + 1} for batch at offset {offset}: {e}"
-                    )
-                    await asyncio.sleep(self.retry_delay * (attempt + 1))
-        return []
+            result = self._post_with_retry(
+                f"{self.base_url}/rest/api/3/search/jql",
+                body,
+            )
+            page_issues = result.get("issues", [])
+            issues.extend(page_issues)
+
+            next_token = result.get("nextPageToken")
+            if not next_token:
+                break
+
+        return issues
+
+    def _get_approximate_count(self) -> int:
+        """POST /rest/api/3/search/approximate-count for issue count estimate."""
+        result = self._post_with_retry(
+            f"{self.base_url}/rest/api/3/search/approximate-count",
+            {"jql": self.query},
+        )
+        return int(result.get("count", 0))
+
+    def _post_with_retry(self, url: str, body: dict) -> dict:
+        """POST with retry on transient/rate-limit errors."""
+        for attempt in range(self.number_of_retries):
+            try:
+                response = requests.post(
+                    url,
+                    headers=self._json_headers,
+                    json=body,
+                    timeout=(5, 30),
+                )
+                self._raise_for_status(response)
+                return response.json()
+            except JiraCloudAPIError as exc:
+                if exc.status_code not in (429, 500, 502, 503, 504):
+                    raise
+                if attempt == self.number_of_retries - 1:
+                    raise
+                logger.debug(
+                    "Retry {}/{} after HTTP {}: {}",
+                    attempt + 1,
+                    self.number_of_retries,
+                    exc.status_code,
+                    exc,
+                )
+                time.sleep(self.retry_delay * (2**attempt))
+            except Exception as exc:
+                if attempt == self.number_of_retries - 1:
+                    raise
+                logger.debug(
+                    "Retry {}/{}: {}",
+                    attempt + 1,
+                    self.number_of_retries,
+                    exc,
+                )
+                time.sleep(self.retry_delay * (2**attempt))
+        raise RuntimeError("unreachable")  # pragma: no cover
+
+    @staticmethod
+    def _raise_for_status(response: requests.Response) -> None:
+        """Raise JiraCloudAPIError for non-success HTTP responses."""
+        if response.ok:
+            return
+        message = "Unknown error"
+        try:
+            error_body = response.json()
+            if "errorMessages" in error_body:
+                message = "; ".join(error_body["errorMessages"])
+            elif "message" in error_body:
+                message = str(error_body["message"])
+        except Exception:
+            message = response.text[:500] if response.text else message
+        raise JiraCloudAPIError(
+            status_code=response.status_code,
+            message=message,
+            url=str(response.url),
+        )
 
     async def _enrich_with_attachments(self, issues: list) -> list:
         """Download attachment bytes for all issues concurrently."""

--- a/packages/indexed-connectors/src/connectors/jira/unified_jira_document_reader.py
+++ b/packages/indexed-connectors/src/connectors/jira/unified_jira_document_reader.py
@@ -266,7 +266,9 @@ class UnifiedJiraDocumentReader:
         """
 
         def do_request():
-            # Use jql with limit=1 to get total count efficiently
+            if self.auth_type == JiraAuthType.CLOUD:
+                result = self._client.approximate_issue_count(self.query)
+                return int(result.get("count", 0))
             result = self._client.jql(self.query, fields=self.fields, start=0, limit=1)
             return result.get("total", 0)
 
@@ -296,7 +298,37 @@ class UnifiedJiraDocumentReader:
 
     def __read_items(self):
         """Read items in batches using the batch utility."""
+        if self.auth_type == JiraAuthType.CLOUD:
+            return self.__read_items_cloud()
+        return self.__read_items_server()
 
+    def __read_items_cloud(self):
+        """Read Cloud issues via Enhanced JQL API with nextPageToken pagination."""
+
+        def read_batch_func(start_at, batch_size, cursor):
+            result = self._client.enhanced_jql(
+                jql=self.query,
+                fields=self.fields,
+                limit=batch_size,
+                nextPageToken=cursor,
+            )
+            issues = result.get("issues", [])
+            if result.get("nextPageToken"):
+                result["_continuation_total"] = start_at + len(issues) + 1
+            else:
+                result["_continuation_total"] = start_at + len(issues)
+            return result
+
+        return read_items_in_batches(
+            read_batch_func,
+            fetch_items_from_result_func=lambda result: result["issues"],
+            fetch_total_from_result_func=lambda result: result["_continuation_total"],
+            batch_size=self.batch_size,
+            max_skipped_items_in_row=self.max_skipped_items_in_row,
+            cursor_parser=UnifiedJiraDocumentReader.__parse_next_page_token,
+        )
+
+    def __read_items_server(self):
         def read_batch_func(start_at, batch_size):
             return self.__request_items(start_at=start_at, max_results=batch_size)
 
@@ -307,6 +339,11 @@ class UnifiedJiraDocumentReader:
             batch_size=self.batch_size,
             max_skipped_items_in_row=self.max_skipped_items_in_row,
         )
+
+    @staticmethod
+    def __parse_next_page_token(result: dict) -> str | None:
+        """Extract nextPageToken for cursor-based pagination."""
+        return result.get("nextPageToken")
 
     def __request_items(self, start_at: int, max_results: int):
         """Request a batch of items from Jira.

--- a/packages/indexed-connectors/src/connectors/jira/unified_jira_document_reader.py
+++ b/packages/indexed-connectors/src/connectors/jira/unified_jira_document_reader.py
@@ -5,7 +5,7 @@ JiraDocumentReader into a single parameterized class, following DRY principles.
 """
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Iterator, Optional
 from atlassian import Jira
 
 from utils.retry import execute_with_retry
@@ -296,21 +296,33 @@ class UnifiedJiraDocumentReader:
             "fields": self.fields,
         }
 
-    def __read_items(self):
+    def __read_items(self) -> Iterator[dict[str, Any]]:
         """Read items in batches using the batch utility."""
         if self.auth_type == JiraAuthType.CLOUD:
             return self.__read_items_cloud()
         return self.__read_items_server()
 
-    def __read_items_cloud(self):
+    def __read_items_cloud(self) -> Iterator[dict[str, Any]]:
         """Read Cloud issues via Enhanced JQL API with nextPageToken pagination."""
 
-        def read_batch_func(start_at, batch_size, cursor):
-            result = self._client.enhanced_jql(
-                jql=self.query,
-                fields=self.fields,
-                limit=batch_size,
-                nextPageToken=cursor,
+        def read_batch_func(
+            start_at: int,
+            batch_size: int,
+            cursor: str | None,
+        ) -> dict[str, Any]:
+            def do_request() -> dict[str, Any]:
+                return self._client.enhanced_jql(
+                    jql=self.query,
+                    fields=self.fields,
+                    limit=batch_size,
+                    nextPageToken=cursor,
+                )
+
+            result = execute_with_retry(
+                do_request,
+                f"Requesting Cloud items at {start_at} with max {batch_size}",
+                self.number_of_retries,
+                self.retry_delay,
             )
             issues = result.get("issues", [])
             if result.get("nextPageToken"):
@@ -328,8 +340,8 @@ class UnifiedJiraDocumentReader:
             cursor_parser=UnifiedJiraDocumentReader.__parse_next_page_token,
         )
 
-    def __read_items_server(self):
-        def read_batch_func(start_at, batch_size):
+    def __read_items_server(self) -> Iterator[dict[str, Any]]:
+        def read_batch_func(start_at: int, batch_size: int) -> dict[str, Any]:
             return self.__request_items(start_at=start_at, max_results=batch_size)
 
         return read_items_in_batches(
@@ -341,7 +353,7 @@ class UnifiedJiraDocumentReader:
         )
 
     @staticmethod
-    def __parse_next_page_token(result: dict) -> str | None:
+    def __parse_next_page_token(result: dict[str, Any]) -> str | None:
         """Extract nextPageToken for cursor-based pagination."""
         return result.get("nextPageToken")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ markers = [
     "unit_api: marks unit API tests",
     "benchmark: marks benchmark tests",
     "connectors: marks connector functionality tests",
+    "integration: marks integration tests",
     "indexed: marks main app integration tests",
 ]
 addopts = [

--- a/tests/system/test_connectors_e2e.py
+++ b/tests/system/test_connectors_e2e.py
@@ -6,6 +6,8 @@ using mocked API responses (no real Jira/Confluence instances needed).
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from connectors.confluence.confluence_document_converter import (
@@ -28,14 +30,22 @@ pytestmark = pytest.mark.connectors
 # ---------------------------------------------------------------------------
 
 
-def _make_fake_jira_class(issues: list[dict]):
+def _make_fake_jira_class(issues: list[dict[str, Any]]):
     """Create a fake Jira class that returns the given issues from jql()."""
 
     class _FakeJira:
-        def __init__(self, **kwargs):
+        def __init__(self, **kwargs: Any) -> None:
             self._issues = issues
 
-        def jql(self, jql, fields=None, start=0, limit=50, expand=None, **kwargs):
+        def jql(
+            self,
+            jql: str,
+            fields: str | list[str] | None = None,
+            start: int = 0,
+            limit: int = 50,
+            expand: str | list[str] | None = None,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
             batch = self._issues[start : start + limit]
             return {
                 "issues": batch,
@@ -46,30 +56,30 @@ def _make_fake_jira_class(issues: list[dict]):
 
         def enhanced_jql(
             self,
-            jql,
-            fields=None,
-            nextPageToken=None,
-            limit=50,
-            expand=None,
-            **kwargs,
-        ):
+            jql: str,
+            fields: str | list[str] | None = None,
+            nextPageToken: str | None = None,
+            limit: int = 50,
+            expand: str | list[str] | None = None,
+            **kwargs: Any,
+        ) -> dict[str, Any]:
             start = int(nextPageToken) if nextPageToken else 0
             batch = (
                 self._issues[start : start + limit] if limit else self._issues[start:]
             )
-            result = {"issues": batch}
+            result: dict[str, Any] = {"issues": batch}
             next_start = start + len(batch)
             if next_start < len(self._issues):
                 result["nextPageToken"] = str(next_start)
             return result
 
-        def approximate_issue_count(self, jql: str) -> dict:
+        def approximate_issue_count(self, jql: str) -> dict[str, Any]:
             return {"count": len(self._issues)}
 
     return _FakeJira
 
 
-def _make_adf_text(text: str) -> dict:
+def _make_adf_text(text: str) -> dict[str, Any]:
     """Create a simple ADF paragraph containing the given text."""
     return {
         "type": "doc",
@@ -87,10 +97,10 @@ def _make_jira_issue(
     key: str,
     summary: str,
     base_url: str = "https://acme.atlassian.net",
-    description=None,
-    comments: list | None = None,
+    description: dict[str, Any] | str | None = None,
+    comments: list[dict[str, Any]] | None = None,
     updated: str = "2026-01-15T10:00:00.000+0000",
-) -> dict:
+) -> dict[str, Any]:
     """Build a realistic Jira issue dict."""
     return {
         "key": key,
@@ -112,21 +122,27 @@ def _make_jira_issue(
 class _FakeResponse:
     """Minimal requests.Response stand-in."""
 
-    def __init__(self, json_data: dict):
+    def __init__(self, json_data: dict[str, Any]) -> None:
         self._json = json_data
         self.status_code = 200
 
-    def json(self):
+    def json(self) -> dict[str, Any]:
         return self._json
 
-    def raise_for_status(self):
+    def raise_for_status(self) -> None:
         pass
 
 
-def _make_fake_confluence_get(pages: list[dict]):
+def _make_fake_confluence_get(pages: list[dict[str, Any]]):
     """Return a function that mimics requests.get for the Confluence reader."""
 
-    def fake_get(url, headers=None, params=None, auth=None, **kwargs):
+    def fake_get(
+        url: str,
+        headers: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
+        auth: Any = None,
+        **kwargs: Any,
+    ) -> _FakeResponse:
         params = params or {}
         start = params.get("start", 0)
         limit = params.get("limit", 50)
@@ -174,13 +190,13 @@ def _make_confluence_page(
 # ---------------------------------------------------------------------------
 
 
-def _run_jira_pipeline(issues: list[dict]) -> list[dict]:
+def _run_jira_pipeline(issues: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert raw issues through the Jira converter and return v1 docs."""
     converter = UnifiedJiraDocumentConverter()
     return [converter.convert(issue)[0] for issue in issues]
 
 
-def _run_confluence_pipeline(documents) -> list[dict]:
+def _run_confluence_pipeline(documents: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert raw reader output through the Confluence converter."""
     converter = ConfluenceDocumentConverter()
     return [converter.convert(doc)[0] for doc in documents]

--- a/tests/system/test_connectors_e2e.py
+++ b/tests/system/test_connectors_e2e.py
@@ -44,6 +44,30 @@ def _make_fake_jira_class(issues: list[dict]):
                 "maxResults": limit,
             }
 
+        def enhanced_jql(
+            self,
+            jql,
+            fields=None,
+            nextPageToken=None,
+            limit=50,
+            expand=None,
+            **kwargs,
+        ):
+            start = int(nextPageToken) if nextPageToken else 0
+            batch = (
+                self._issues[start : start + limit]
+                if limit
+                else self._issues[start:]
+            )
+            result = {"issues": batch}
+            next_start = start + len(batch)
+            if next_start < len(self._issues):
+                result["nextPageToken"] = str(next_start)
+            return result
+
+        def approximate_issue_count(self, jql: str) -> dict:
+            return {"count": len(self._issues)}
+
     return _FakeJira
 
 

--- a/tests/system/test_connectors_e2e.py
+++ b/tests/system/test_connectors_e2e.py
@@ -55,9 +55,7 @@ def _make_fake_jira_class(issues: list[dict]):
         ):
             start = int(nextPageToken) if nextPageToken else 0
             batch = (
-                self._issues[start : start + limit]
-                if limit
-                else self._issues[start:]
+                self._issues[start : start + limit] if limit else self._issues[start:]
             )
             result = {"issues": batch}
             next_start = start + len(batch)

--- a/tests/unit/indexed_connectors/jira/test_async_reader_attachments.py
+++ b/tests/unit/indexed_connectors/jira/test_async_reader_attachments.py
@@ -44,11 +44,11 @@ def test_read_all_documents_without_attachments():
 
     issues = [{"key": "T-1", "fields": {"updated": "2024-01-01"}}]
 
-    with patch.object(reader, "_read_all_async", new_callable=AsyncMock) as mock_read:
-        mock_read.return_value = issues
+    with patch.object(reader, "_read_issues_sync", return_value=issues) as mock_read:
         result = reader.read_all_documents()
 
     assert result == issues
+    mock_read.assert_called_once()
 
 
 def test_enrich_with_attachments_downloads():

--- a/tests/unit/indexed_connectors/jira/test_reader_attachments.py
+++ b/tests/unit/indexed_connectors/jira/test_reader_attachments.py
@@ -1,7 +1,11 @@
 """Tests for Jira reader attachment fetching."""
 
-import pytest
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from connectors.jira.unified_jira_document_reader import (
     UnifiedJiraDocumentReader,
@@ -14,7 +18,14 @@ pytestmark = pytest.mark.connectors
 class FakeJiraWithAttachments:
     """Fake Jira client that returns issues with attachment metadata."""
 
-    def __init__(self, url=None, username=None, password=None, cloud=None, **kwargs):
+    def __init__(
+        self,
+        url: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        cloud: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
         self._issues = [
             {
                 "key": "ATT-1",
@@ -38,38 +49,52 @@ class FakeJiraWithAttachments:
             },
         ]
 
-    def jql(self, jql, fields=None, start=0, limit=50, **kwargs):
+    def jql(
+        self,
+        jql: str,
+        fields: str | list[str] | None = None,
+        start: int = 0,
+        limit: int = 50,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         batch = self._issues[start : start + limit]
         return {"issues": batch, "total": len(self._issues)}
 
     def enhanced_jql(
         self,
-        jql,
-        fields=None,
-        nextPageToken=None,
-        limit=50,
-        expand=None,
-        **kwargs,
-    ):
+        jql: str,
+        fields: str | list[str] | None = None,
+        nextPageToken: str | None = None,
+        limit: int = 50,
+        expand: str | list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         start = int(nextPageToken) if nextPageToken else 0
         batch = self._issues[start : start + limit] if limit else self._issues[start:]
-        result = {"issues": batch}
+        result: dict[str, Any] = {"issues": batch}
         next_start = start + len(batch)
         if next_start < len(self._issues):
             result["nextPageToken"] = str(next_start)
         return result
 
-    def approximate_issue_count(self, jql: str) -> dict:
+    def approximate_issue_count(self, jql: str) -> dict[str, Any]:
         return {"count": len(self._issues)}
 
 
 class FakeJiraNoAttachments:
-    def __init__(self, **kwargs):
+    def __init__(self, **kwargs: Any) -> None:
         self._issues = [
             {"key": "NO-1", "fields": {"updated": "2024-01-01T00:00:00.000+0000"}},
         ]
 
-    def jql(self, jql, fields=None, start=0, limit=50, **kwargs):
+    def jql(
+        self,
+        jql: str,
+        fields: str | list[str] | None = None,
+        start: int = 0,
+        limit: int = 50,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         return {
             "issues": self._issues[start : start + limit],
             "total": len(self._issues),

--- a/tests/unit/indexed_connectors/jira/test_reader_attachments.py
+++ b/tests/unit/indexed_connectors/jira/test_reader_attachments.py
@@ -42,6 +42,26 @@ class FakeJiraWithAttachments:
         batch = self._issues[start : start + limit]
         return {"issues": batch, "total": len(self._issues)}
 
+    def enhanced_jql(
+        self,
+        jql,
+        fields=None,
+        nextPageToken=None,
+        limit=50,
+        expand=None,
+        **kwargs,
+    ):
+        start = int(nextPageToken) if nextPageToken else 0
+        batch = self._issues[start : start + limit] if limit else self._issues[start:]
+        result = {"issues": batch}
+        next_start = start + len(batch)
+        if next_start < len(self._issues):
+            result["nextPageToken"] = str(next_start)
+        return result
+
+    def approximate_issue_count(self, jql: str) -> dict:
+        return {"count": len(self._issues)}
+
 
 class FakeJiraNoAttachments:
     def __init__(self, **kwargs):

--- a/tests/unit/indexed_connectors/jira/test_reader_integration.py
+++ b/tests/unit/indexed_connectors/jira/test_reader_integration.py
@@ -1,0 +1,120 @@
+"""End-to-end mocked integration tests for AsyncJiraCloudDocumentReader.
+
+Exercises read_all_documents() with requests.post mocked so the full sequence
+approximate-count (optional) → search/jql pagination runs through real code.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from connectors.jira.async_jira_cloud_reader import AsyncJiraCloudDocumentReader
+
+pytestmark = pytest.mark.connectors
+
+
+def _search_resp(issues: list, next_token: str | None = None) -> MagicMock:
+    payload: dict = {"issues": issues}
+    if next_token:
+        payload["nextPageToken"] = next_token
+    resp = MagicMock()
+    resp.json.return_value = payload
+    resp.ok = True
+    resp.status_code = 200
+    resp.url = "https://acme.atlassian.net/rest/api/3/search/jql"
+    resp.text = ""
+    return resp
+
+
+def _count_resp(count: int) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {"count": count}
+    resp.ok = True
+    resp.status_code = 200
+    resp.url = "https://acme.atlassian.net/rest/api/3/search/approximate-count"
+    resp.text = ""
+    return resp
+
+
+def _make_reader(**kwargs: object) -> AsyncJiraCloudDocumentReader:
+    defaults: dict = {
+        "base_url": "https://acme.atlassian.net",
+        "query": "project = TEST",
+        "email": "user@acme.com",
+        "api_token": "tok",
+        "batch_size": 2,
+        "include_attachments": False,
+    }
+    defaults.update(kwargs)
+    return AsyncJiraCloudDocumentReader(**defaults)
+
+
+def test_read_all_documents_integration_multi_page() -> None:
+    """read_all_documents orchestrates sequential search/jql pages."""
+    reader = _make_reader()
+    issues = [{"key": f"T-{i}", "fields": {"updated": "2024-01-01"}} for i in range(3)]
+    responses = [
+        _search_resp(issues[:2], next_token="2"),
+        _search_resp(issues[2:]),
+    ]
+
+    with patch("requests.post", side_effect=responses) as mock_post:
+        result = reader.read_all_documents()
+
+    assert len(result) == 3
+    assert result[0]["key"] == "T-0"
+    assert mock_post.call_count == 2
+    first_body = mock_post.call_args_list[0].kwargs["json"]
+    assert first_body["jql"] == "project = TEST"
+    assert "nextPageToken" not in first_body
+    second_body = mock_post.call_args_list[1].kwargs["json"]
+    assert second_body["nextPageToken"] == "2"
+
+
+def test_get_number_of_documents_integration() -> None:
+    """get_number_of_documents hits approximate-count endpoint."""
+    reader = _make_reader()
+
+    with patch("requests.post", return_value=_count_resp(17)) as mock_post:
+        count = reader.get_number_of_documents()
+
+    assert count == 17
+    assert mock_post.call_count == 1
+    assert "approximate-count" in mock_post.call_args.args[0]
+    assert mock_post.call_args.kwargs["json"] == {"jql": "project = TEST"}
+
+
+def test_read_all_documents_empty_result() -> None:
+    """Zero issues returns empty list without follow-up pages."""
+    reader = _make_reader()
+
+    with patch("requests.post", return_value=_search_resp([])) as mock_post:
+        result = reader.read_all_documents()
+
+    assert result == []
+    assert mock_post.call_count == 1
+
+
+def test_search_api_error_surfaces_jira_cloud_api_error() -> None:
+    """Removed-endpoint style errors raise JiraCloudAPIError."""
+    from connectors.jira.async_jira_cloud_reader import JiraCloudAPIError
+
+    reader = _make_reader()
+    resp = MagicMock()
+    resp.ok = False
+    resp.status_code = 410
+    resp.url = "https://acme.atlassian.net/rest/api/3/search"
+    resp.text = ""
+    resp.json.return_value = {
+        "errorMessages": [
+            "The requested API has been removed. "
+            "Please migrate to the /rest/api/3/search/jql API."
+        ],
+        "errors": {},
+    }
+
+    with patch("requests.post", return_value=resp):
+        with pytest.raises(JiraCloudAPIError, match="removed"):
+            reader.read_all_documents()

--- a/tests/unit/indexed_connectors/jira/test_reader_integration.py
+++ b/tests/unit/indexed_connectors/jira/test_reader_integration.py
@@ -6,17 +6,20 @@ approximate-count (optional) → search/jql pagination runs through real code.
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from connectors.jira.async_jira_cloud_reader import AsyncJiraCloudDocumentReader
 
-pytestmark = pytest.mark.connectors
+pytestmark = pytest.mark.integration
 
 
-def _search_resp(issues: list, next_token: str | None = None) -> MagicMock:
-    payload: dict = {"issues": issues}
+def _search_resp(
+    issues: list[dict[str, Any]], next_token: str | None = None
+) -> MagicMock:
+    payload: dict[str, Any] = {"issues": issues}
     if next_token:
         payload["nextPageToken"] = next_token
     resp = MagicMock()
@@ -39,7 +42,7 @@ def _count_resp(count: int) -> MagicMock:
 
 
 def _make_reader(**kwargs: object) -> AsyncJiraCloudDocumentReader:
-    defaults: dict = {
+    defaults: dict[str, object] = {
         "base_url": "https://acme.atlassian.net",
         "query": "project = TEST",
         "email": "user@acme.com",

--- a/tests/unit/indexed_connectors/jira/test_readers.py
+++ b/tests/unit/indexed_connectors/jira/test_readers.py
@@ -1,6 +1,9 @@
 """Tests for Jira document readers."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
+from connectors.jira.async_jira_cloud_reader import AsyncJiraCloudDocumentReader
 from connectors.jira.unified_jira_document_reader import (
     UnifiedJiraDocumentReader,
     JiraAuthType,
@@ -17,14 +20,25 @@ class FakeJiraCloud:
             {"key": "ISSUE-3", "fields": {"updated": "2024-01-03T00:00:00.000+0000"}},
         ]
 
-    def jql(self, jql, fields=None, start=0, limit=50, expand=None, **kwargs):
+    def approximate_issue_count(self, jql: str) -> dict:
+        return {"count": len(self._issues)}
+
+    def enhanced_jql(
+        self,
+        jql,
+        fields=None,
+        nextPageToken=None,
+        limit=50,
+        expand=None,
+        **kwargs,
+    ):
+        start = int(nextPageToken) if nextPageToken else 0
         batch = self._issues[start : start + limit] if limit else self._issues[start:]
-        return {
-            "issues": batch,
-            "total": len(self._issues),
-            "startAt": start,
-            "maxResults": limit,
-        }
+        result = {"issues": batch}
+        next_start = start + len(batch)
+        if next_start < len(self._issues):
+            result["nextPageToken"] = str(next_start)
+        return result
 
 
 class FakeJiraServer:
@@ -46,9 +60,42 @@ class FakeJiraServer:
         }
 
 
+def _make_search_response(issues: list, next_token: str | None = None) -> MagicMock:
+    resp = MagicMock()
+    payload: dict = {"issues": issues}
+    if next_token:
+        payload["nextPageToken"] = next_token
+    resp.json.return_value = payload
+    resp.ok = True
+    resp.status_code = 200
+    resp.url = "https://acme.atlassian.net/rest/api/3/search/jql"
+    resp.text = ""
+    return resp
+
+
+def _make_count_response(count: int) -> MagicMock:
+    resp = MagicMock()
+    resp.json.return_value = {"count": count}
+    resp.ok = True
+    resp.status_code = 200
+    resp.url = "https://acme.atlassian.net/rest/api/3/search/approximate-count"
+    resp.text = ""
+    return resp
+
+
+@pytest.fixture
+def async_reader():
+    return AsyncJiraCloudDocumentReader(
+        base_url="https://acme.atlassian.net",
+        query="project = TEST",
+        email="user@acme.com",
+        api_token="tok",
+        batch_size=2,
+    )
+
+
 def test_cloud_reader_count_and_pagination(monkeypatch):
     """Test cloud reader document counting and pagination."""
-    # Patch the Jira class in the unified reader module
     import connectors.jira.unified_jira_document_reader as unified_mod
 
     monkeypatch.setattr(unified_mod, "Jira", FakeJiraCloud, raising=True)
@@ -65,7 +112,6 @@ def test_cloud_reader_count_and_pagination(monkeypatch):
     assert reader.get_number_of_documents() == 3
 
     docs = list(reader.read_all_documents())
-    # We yielded raw issue objects, ensure full set arrived
     assert len(docs) == 3
     assert docs[0]["key"] == "ISSUE-1"
     assert docs[-1]["key"] == "ISSUE-3"
@@ -92,6 +138,53 @@ def test_server_reader_count_and_pagination(monkeypatch):
     assert docs[0]["key"] == "S-1"
 
 
+def test_pagination_terminates_at_next_page_token(async_reader):
+    """Async reader fetches all pages until nextPageToken is absent."""
+    issues = [{"key": f"I-{i}", "fields": {"updated": "2024-01-01"}} for i in range(5)]
+    responses = [
+        _make_search_response(issues[:2], next_token="2"),
+        _make_search_response(issues[2:4], next_token="4"),
+        _make_search_response(issues[4:]),
+    ]
+
+    with patch("requests.post", side_effect=responses) as mock_post:
+        result = async_reader._read_issues_sync()
+
+    assert len(result) == 5
+    assert mock_post.call_count == 3
+    assert all(
+        call.kwargs["json"]["jql"] == "project = TEST"
+        for call in mock_post.call_args_list
+    )
+
+
+def test_pagination_with_exact_page_boundary(async_reader):
+    """Async reader stops cleanly when last page fills the batch exactly."""
+    issues = [{"key": f"I-{i}", "fields": {"updated": "2024-01-01"}} for i in range(4)]
+    responses = [
+        _make_search_response(issues[:2], next_token="2"),
+        _make_search_response(issues[2:]),
+    ]
+
+    with patch("requests.post", side_effect=responses) as mock_post:
+        result = async_reader._read_issues_sync()
+
+    assert len(result) == 4
+    assert mock_post.call_count == 2
+
+
+def test_async_reader_approximate_count(async_reader):
+    """get_number_of_documents uses approximate-count endpoint."""
+    with patch(
+        "requests.post",
+        return_value=_make_count_response(42),
+    ) as mock_post:
+        count = async_reader.get_number_of_documents()
+
+    assert count == 42
+    assert "approximate-count" in mock_post.call_args.args[0]
+
+
 def test_reader_validation_cloud_requires_email_and_token():
     """Test cloud auth validation."""
     with pytest.raises(
@@ -101,7 +194,6 @@ def test_reader_validation_cloud_requires_email_and_token():
             base_url="https://acme.atlassian.net",
             query="project = TEST",
             auth_type=JiraAuthType.CLOUD,
-            # Missing email and api_token
         )
 
 
@@ -112,7 +204,6 @@ def test_reader_validation_server_token_requires_token():
             base_url="https://jira.example.com",
             query="project = TEST",
             auth_type=JiraAuthType.SERVER_TOKEN,
-            # Missing token
         )
 
 
@@ -126,7 +217,6 @@ def test_reader_validation_server_creds_requires_login_password():
             base_url="https://jira.example.com",
             query="project = TEST",
             auth_type=JiraAuthType.SERVER_CREDENTIALS,
-            # Missing login and password
         )
 
 
@@ -134,7 +224,7 @@ def test_reader_url_validation_cloud():
     """Test cloud URL validation."""
     with pytest.raises(ValueError, match="Cloud URLs must end with .atlassian.net"):
         UnifiedJiraDocumentReader(
-            base_url="https://jira.example.com",  # Wrong URL for cloud
+            base_url="https://jira.example.com",
             query="project = TEST",
             auth_type=JiraAuthType.CLOUD,
             email="x@acme.com",
@@ -148,7 +238,7 @@ def test_reader_url_validation_server():
         ValueError, match="Server/DC URLs should not end with .atlassian.net"
     ):
         UnifiedJiraDocumentReader(
-            base_url="https://acme.atlassian.net",  # Wrong URL for server
+            base_url="https://acme.atlassian.net",
             query="project = TEST",
             auth_type=JiraAuthType.SERVER_TOKEN,
             token="token",

--- a/tests/unit/indexed_connectors/jira/test_readers.py
+++ b/tests/unit/indexed_connectors/jira/test_readers.py
@@ -1,5 +1,8 @@
 """Tests for Jira document readers."""
 
+from __future__ import annotations
+
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,28 +16,35 @@ pytestmark = pytest.mark.connectors  # Mark all tests in this file as connector 
 
 
 class FakeJiraCloud:
-    def __init__(self, url=None, username=None, password=None, cloud=None, **kwargs):
+    def __init__(
+        self,
+        url: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        cloud: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
         self._issues = [
             {"key": "ISSUE-1", "fields": {"updated": "2024-01-01T00:00:00.000+0000"}},
             {"key": "ISSUE-2", "fields": {"updated": "2024-01-02T00:00:00.000+0000"}},
             {"key": "ISSUE-3", "fields": {"updated": "2024-01-03T00:00:00.000+0000"}},
         ]
 
-    def approximate_issue_count(self, jql: str) -> dict:
+    def approximate_issue_count(self, jql: str) -> dict[str, Any]:
         return {"count": len(self._issues)}
 
     def enhanced_jql(
         self,
-        jql,
-        fields=None,
-        nextPageToken=None,
-        limit=50,
-        expand=None,
-        **kwargs,
-    ):
+        jql: str,
+        fields: str | list[str] | None = None,
+        nextPageToken: str | None = None,
+        limit: int = 50,
+        expand: str | list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         start = int(nextPageToken) if nextPageToken else 0
         batch = self._issues[start : start + limit] if limit else self._issues[start:]
-        result = {"issues": batch}
+        result: dict[str, Any] = {"issues": batch}
         next_start = start + len(batch)
         if next_start < len(self._issues):
             result["nextPageToken"] = str(next_start)
@@ -43,14 +53,28 @@ class FakeJiraCloud:
 
 class FakeJiraServer:
     def __init__(
-        self, url=None, token=None, username=None, password=None, cloud=None, **kwargs
-    ):
+        self,
+        url: str | None = None,
+        token: str | None = None,
+        username: str | None = None,
+        password: str | None = None,
+        cloud: bool | None = None,
+        **kwargs: Any,
+    ) -> None:
         self._issues = [
             {"key": "S-1", "fields": {"updated": "2024-02-01T00:00:00.000+0000"}},
             {"key": "S-2", "fields": {"updated": "2024-02-02T00:00:00.000+0000"}},
         ]
 
-    def jql(self, jql, fields=None, start=0, limit=50, expand=None, **kwargs):
+    def jql(
+        self,
+        jql: str,
+        fields: str | list[str] | None = None,
+        start: int = 0,
+        limit: int = 50,
+        expand: str | list[str] | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         batch = self._issues[start : start + limit] if limit else self._issues[start:]
         return {
             "issues": batch,
@@ -60,9 +84,11 @@ class FakeJiraServer:
         }
 
 
-def _make_search_response(issues: list, next_token: str | None = None) -> MagicMock:
+def _make_search_response(
+    issues: list[dict[str, Any]], next_token: str | None = None
+) -> MagicMock:
     resp = MagicMock()
-    payload: dict = {"issues": issues}
+    payload: dict[str, Any] = {"issues": issues}
     if next_token:
         payload["nextPageToken"] = next_token
     resp.json.return_value = payload
@@ -84,7 +110,7 @@ def _make_count_response(count: int) -> MagicMock:
 
 
 @pytest.fixture
-def async_reader():
+def async_reader() -> AsyncJiraCloudDocumentReader:
     return AsyncJiraCloudDocumentReader(
         base_url="https://acme.atlassian.net",
         query="project = TEST",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes #129

## Problem

Jira Cloud indexing fails because Atlassian removed `GET/POST /rest/api/3/search`. The connector now receives:

```
The requested API has been removed. Please migrate to the /rest/api/3/search/jql API.
```

See [CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046).

## Changes

### `AsyncJiraCloudDocumentReader` (primary Cloud path)
- Replaced deprecated `/rest/api/3/search` + `startAt` parallel batches with sequential `POST /rest/api/3/search/jql` + `nextPageToken`
- `get_number_of_documents()` now uses `POST /rest/api/3/search/approximate-count`
- Added `JiraCloudAPIError` and `_post_with_retry()` (Outline/Confluence pattern)
- Kept async concurrent attachment downloads unchanged

### `UnifiedJiraDocumentReader` (Cloud / deprecated wrappers)
- Cloud path uses `enhanced_jql()` with `read_items_in_batches` + `__parse_next_page_token`
- Cloud count uses `approximate_issue_count()`
- Server/DC paths unchanged (`jql()` + offset pagination)

### Tests
- Extended `test_readers.py` with cursor pagination tests
- Added `test_reader_integration.py` (Outline pattern)
- Updated E2E and attachment test fakes for `enhanced_jql`

## Verification

```bash
uv run ruff check packages/indexed-connectors/src/connectors/jira/ tests/unit/indexed_connectors/jira/
uv run pytest tests/unit/indexed_connectors/jira/ tests/system/test_connectors_e2e.py::TestJiraConnectorE2E -q
uv run pytest -q --ignore=tests/benchmarks  # 1342 passed
```

## Out of scope

- Consolidating async + unified readers
- Windowed streaming / Iterator return type
- Confluence search deprecation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f31254c4-ab53-4ddc-bd01-dfd6332ef424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f31254c4-ab53-4ddc-bd01-dfd6332ef424"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved Jira Cloud issue retrieval using cursor-based pagination (`nextPageToken`) with retry/backoff for transient failures.
  * Enhanced Jira Cloud error handling by surfacing a dedicated, clearer API error on failed responses.
  * Updated Jira Cloud document counting to use the approximate-count endpoint for more consistent results.

* **Testing**
  * Added integration coverage for multi-page pagination, approximate counts, empty results, and error propagation.
  * Updated Jira mocks and unit tests to reflect the new Cloud paging/count behavior, including attachment-related sync flow.

* **Chores**
  * Added an `integration` pytest marker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->