### PR TITLE
chore: gitignore coverage.json artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ _build_meta.py
 .coverage
 htmlcov*/
 coverage.xml
+coverage.json
 .tox/
 
 # Type checking


### PR DESCRIPTION
Part of the **#86 split** — independent, base `main`, merge any time.

**The coverage CI is fixed by *omission*, not by a change here.** #86's red coverage job was caused by its `python-cov.yml` edit dropping the explicit `--cov=` targets (the active config is `tests/pytest.ini`, so `pyproject.toml` addopts are dead → no `coverage.xml`). **None** of the split branches carry that edit, so coverage CI stays green across the whole stack.

This branch therefore ships only the harmless `.gitignore` line (ignore `coverage.json`).

Note: #86 also bumped the codecov gate 70%→85%. **Dropped here** — measured unit coverage is **81%**, so an 85% gate would turn the check red. Raise the gate in a separate change once coverage reaches 85%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)