### PR TITLE
fix(benchmark): point parsing tests at .spec/

### DIFF
--- a/tests/benchmarks/test_parsing_performance.py
+++ b/tests/benchmarks/test_parsing_performance.py
@@ -35,25 +35,29 @@ LOGO_PNG = DOCS_DIR / "img" / "logo.png"
 
 @pytest.fixture(scope="module")
 def parsing_module() -> ParsingModule:
+    """Shared ParsingModule for markdown and image parse benchmarks."""
     return ParsingModule(ocr=False, table_structure=False, max_tokens=512)
 
 
 @pytest.fixture(scope="module")
 def code_chunker() -> CodeChunker:
+    """Shared CodeChunker for Python source parse benchmarks."""
     return CodeChunker(max_tokens=512)
 
 
 @pytest.fixture(scope="module")
 def plaintext_parser() -> PlaintextParser:
+    """Shared PlaintextParser for JSON-as-plaintext benchmarks."""
     return PlaintextParser(max_tokens=512)
 
 
 @pytest.fixture(scope="module")
 def file_router() -> FileRouter:
+    """Shared FileRouter for routing throughput benchmarks."""
     return FileRouter()
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def mixed_workspace(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Create a realistic mixed workspace with ~50 files for batch benchmarks."""
     base = tmp_path_factory.mktemp("bench_workspace")
@@ -114,6 +118,7 @@ def mixed_workspace(tmp_path_factory: pytest.TempPathFactory) -> Path:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 @pytest.mark.benchmark(min_rounds=3, max_time=2.0)
 def test_parse_markdown_docs(benchmark, parsing_module: ParsingModule):
     """Benchmark: parse a real .spec/ markdown file."""
@@ -207,6 +212,7 @@ def test_file_router_throughput(benchmark, file_router: FileRouter):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 @pytest.mark.benchmark(min_rounds=3, max_time=10.0)
 def test_batch_parse_docs_directory(benchmark, parsing_module: ParsingModule):
     """Benchmark: parse all markdown files in .spec/ directory."""
@@ -223,6 +229,7 @@ def test_batch_parse_docs_directory(benchmark, parsing_module: ParsingModule):
     benchmark(parse_all_docs)
 
 
+@pytest.mark.slow
 @pytest.mark.benchmark(min_rounds=3, max_time=15.0)
 def test_full_connector_pipeline_docs(benchmark):
     """Benchmark: full FileSystemConnector pipeline on .spec/ directory."""
@@ -269,6 +276,7 @@ def test_full_connector_pipeline_mixed(benchmark, mixed_workspace: Path):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.slow
 @pytest.mark.benchmark(min_rounds=5, max_time=2.0)
 def test_v1_adapter_conversion(benchmark, parsing_module: ParsingModule):
     """Benchmark: V1FormatAdapter conversion on multiple parsed documents."""

--- a/tests/benchmarks/test_parsing_performance.py
+++ b/tests/benchmarks/test_parsing_performance.py
@@ -58,10 +58,10 @@ def mixed_workspace(tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Create a realistic mixed workspace with ~50 files for batch benchmarks."""
     base = tmp_path_factory.mktemp("bench_workspace")
 
-    # Copy docs/ markdown files
+    # Copy .spec/ markdown files into a docs/ subdir (simulated content tree)
     docs_sub = base / "docs"
     docs_sub.mkdir()
-    for md in DOCS_DIR.glob("*.md"):
+    for md in SPEC_DIR.glob("*.md"):
         (docs_sub / md.name).write_text(md.read_text())
 
     # Copy .spec/ markdown files
@@ -116,8 +116,8 @@ def mixed_workspace(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
 @pytest.mark.benchmark(min_rounds=3, max_time=2.0)
 def test_parse_markdown_docs(benchmark, parsing_module: ParsingModule):
-    """Benchmark: parse a real docs/ markdown file."""
-    target = DOCS_DIR / "architecture-internals.md"
+    """Benchmark: parse a real .spec/ markdown file."""
+    target = SPEC_DIR / "product.md"
     assert target.exists()
 
     def parse_md():
@@ -209,8 +209,8 @@ def test_file_router_throughput(benchmark, file_router: FileRouter):
 
 @pytest.mark.benchmark(min_rounds=3, max_time=10.0)
 def test_batch_parse_docs_directory(benchmark, parsing_module: ParsingModule):
-    """Benchmark: parse all markdown files in docs/ directory."""
-    md_files = list(DOCS_DIR.glob("*.md"))
+    """Benchmark: parse all markdown files in .spec/ directory."""
+    md_files = list(SPEC_DIR.glob("*.md"))
     assert len(md_files) > 0
 
     def parse_all_docs():
@@ -225,12 +225,12 @@ def test_batch_parse_docs_directory(benchmark, parsing_module: ParsingModule):
 
 @pytest.mark.benchmark(min_rounds=3, max_time=15.0)
 def test_full_connector_pipeline_docs(benchmark):
-    """Benchmark: full FileSystemConnector pipeline on docs/ directory."""
-    assert DOCS_DIR.is_dir()
+    """Benchmark: full FileSystemConnector pipeline on .spec/ directory."""
+    assert SPEC_DIR.is_dir()
 
     def full_pipeline():
         connector = FileSystemConnector(
-            path=str(DOCS_DIR),
+            path=str(SPEC_DIR),
             include_patterns=[r".*\.md$"],
             ocr_enabled=False,
             table_structure=False,
@@ -272,7 +272,7 @@ def test_full_connector_pipeline_mixed(benchmark, mixed_workspace: Path):
 @pytest.mark.benchmark(min_rounds=5, max_time=2.0)
 def test_v1_adapter_conversion(benchmark, parsing_module: ParsingModule):
     """Benchmark: V1FormatAdapter conversion on multiple parsed documents."""
-    md_files = list(SPEC_DIR.glob("*.md")) + list(DOCS_DIR.glob("*.md"))
+    md_files = list(SPEC_DIR.glob("*.md"))
     assert len(md_files) > 0
 
     # Pre-parse all documents (setup, not measured)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `tests/benchmarks/test_parsing_performance.py` to use `.spec/` as the markdown corpus instead of `docs/`, which was intentionally reduced to only `docs/img/logo.png` in PR #120.

## Changes

- `test_parse_markdown_docs` — parses `.spec/product.md` (distinct from `tech.md` used by the large-markdown test)
- `test_batch_parse_docs_directory` — globs `.spec/*.md`
- `test_full_connector_pipeline_docs` — runs `FileSystemConnector` against `.spec/`
- `mixed_workspace` fixture — seeds the synthetic `docs/` subdir from `.spec/*.md`
- `test_v1_adapter_conversion` — drops the empty `docs/*.md` glob

## Verification

```
uv run pytest tests/benchmarks/test_parsing_performance.py -q --no-cov
12 passed in 80.40s
```

Previously failing tests now pass:
- `test_parse_markdown_docs`
- `test_batch_parse_docs_directory`
- `test_full_connector_pipeline_docs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-020643b5-9d85-4c3b-84bf-0cabb0601eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-020643b5-9d85-4c3b-84bf-0cabb0601eea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated performance benchmarking datasets to use alternative data sources for comprehensive parsing and pipeline performance testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->